### PR TITLE
채팅페이지 기능구현

### DIFF
--- a/src/apis/chat.js
+++ b/src/apis/chat.js
@@ -16,3 +16,11 @@ export const getChattingData = ({ chatRoomId }) =>
       chatRoomId,
     })
     .then((response) => response.data);
+
+export const getChattingWithCursor = ({ chatRoomId, cursor }) =>
+  instance
+    .post(`${ENDPOINT}/message/cursor`, {
+      chatRoomId,
+      cursor,
+    })
+    .then((response) => response.data);

--- a/src/apis/chat.js
+++ b/src/apis/chat.js
@@ -24,3 +24,8 @@ export const getChattingWithCursor = ({ chatRoomId, cursor }) =>
       cursor,
     })
     .then((response) => response.data);
+
+export const disconnectChatRoom = ({ chatRoomId }) =>
+  instance
+    .get(`${ENDPOINT}/leave`, { params: { chatRoomId } })
+    .then((response) => response.data);

--- a/src/components/Chat/ChatRoomList/ChatListPageMain.jsx
+++ b/src/components/Chat/ChatRoomList/ChatListPageMain.jsx
@@ -4,7 +4,7 @@ import { useParams } from "react-router-dom";
 import { Card, List } from "@material-tailwind/react";
 import { v4 as uuidv4 } from "uuid";
 import { CHAT_QUERY_KEYS } from "../../../constants/queryKeys";
-import { getChatList } from "../../../apis/chat";
+import { disconnectChatRoom, getChatList } from "../../../apis/chat";
 import ChatRoom from "./ChatRoom";
 import NullChatList from "./NullChatList";
 import useChatNotification from "../../../hooks/useChatNotification";
@@ -20,7 +20,12 @@ export default function ChatListPageMain() {
     error,
   } = useQuery({
     queryKey: CHAT_QUERY_KEYS.chatList,
-    queryFn: getChatList,
+    queryFn: async () => {
+      if (nowChatRoomId) {
+        await disconnectChatRoom({ chatRoomId: nowChatRoomId });
+      }
+      return getChatList();
+    },
   });
   const { connect, disconnect } = useChatNotification(
     "NEW_CHAT_NOTIFICATION",

--- a/src/components/Chat/ChatRoomList/ChatListPageMain.jsx
+++ b/src/components/Chat/ChatRoomList/ChatListPageMain.jsx
@@ -3,17 +3,18 @@ import { useQuery } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
 import { Card, List } from "@material-tailwind/react";
 import { v4 as uuidv4 } from "uuid";
-import { jwtDecode } from "jwt-decode";
 import { CHAT_QUERY_KEYS } from "../../../constants/queryKeys";
 import { getChatList } from "../../../apis/chat";
 import ChatRoom from "./ChatRoom";
 import NullChatList from "./NullChatList";
 import useChatNotification from "../../../hooks/useChatNotification";
-import { getCookie } from "../../../utils/cookie";
+import { useRecoilValue } from "recoil";
+import { memberIdState } from "../../../recoil/atoms/auth";
 
 export default function ChatListPageMain() {
   const { chatRoomId: nowChatRoomId } = useParams();
   const [chatRooms, setChatRooms] = useState([]);
+  const memberId = useRecoilValue(memberIdState);
   const {
     data: { chatRoomList },
     error,
@@ -23,7 +24,7 @@ export default function ChatListPageMain() {
   });
   const { connect, disconnect } = useChatNotification(
     "NEW_CHAT_NOTIFICATION",
-    jwtDecode(getCookie("accessToken")).memberId,
+    memberId,
     (newChatRoom) => {
       setChatRooms((prev) => [JSON.parse(newChatRoom), ...prev]);
     }

--- a/src/components/Chat/ChatRoomList/ChatListPageMain.jsx
+++ b/src/components/Chat/ChatRoomList/ChatListPageMain.jsx
@@ -1,16 +1,18 @@
 import React, { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useParams } from "react-router-dom";
 import { Card, List } from "@material-tailwind/react";
 import { v4 as uuidv4 } from "uuid";
+import { jwtDecode } from "jwt-decode";
 import { CHAT_QUERY_KEYS } from "../../../constants/queryKeys";
 import { getChatList } from "../../../apis/chat";
 import ChatRoom from "./ChatRoom";
 import NullChatList from "./NullChatList";
 import useChatNotification from "../../../hooks/useChatNotification";
-import { jwtDecode } from "jwt-decode";
 import { getCookie } from "../../../utils/cookie";
 
 export default function ChatListPageMain() {
+  const { chatRoomId: nowChatRoomId } = useParams();
   const [chatRooms, setChatRooms] = useState([]);
   const {
     data: { chatRoomList },
@@ -28,10 +30,22 @@ export default function ChatListPageMain() {
   );
 
   useEffect(() => {
-    if (chatRoomList) {
-      setChatRooms(chatRoomList);
-    }
+    if (chatRoomList.length === 0) return;
+
+    setChatRooms(chatRoomList);
   }, [chatRoomList]);
+
+  useEffect(() => {
+    if (nowChatRoomId) {
+      setChatRooms((prev) =>
+        prev.map((chatRoom) =>
+          chatRoom.chatRoomId === nowChatRoomId
+            ? { ...chatRoom, unreadCount: 0 }
+            : chatRoom
+        )
+      );
+    }
+  }, [nowChatRoomId, chatRoomList]);
 
   useEffect(() => {
     connect();
@@ -52,6 +66,7 @@ export default function ChatListPageMain() {
           <ChatRoom
             key={uuidv4()}
             chatRoom={chatRoom}
+            nowChatRoomId={nowChatRoomId}
             chatRooms={chatRooms}
             setChatRooms={setChatRooms}
           />

--- a/src/components/Chat/ChatRoomList/ChatListPageMain.jsx
+++ b/src/components/Chat/ChatRoomList/ChatListPageMain.jsx
@@ -4,7 +4,7 @@ import { useParams } from "react-router-dom";
 import { Card, List } from "@material-tailwind/react";
 import { v4 as uuidv4 } from "uuid";
 import { CHAT_QUERY_KEYS } from "../../../constants/queryKeys";
-import { disconnectChatRoom, getChatList } from "../../../apis/chat";
+import { getChatList } from "../../../apis/chat";
 import ChatRoom from "./ChatRoom";
 import NullChatList from "./NullChatList";
 import useChatNotification from "../../../hooks/useChatNotification";
@@ -20,12 +20,7 @@ export default function ChatListPageMain() {
     error,
   } = useQuery({
     queryKey: CHAT_QUERY_KEYS.chatList,
-    queryFn: async () => {
-      if (nowChatRoomId) {
-        await disconnectChatRoom({ chatRoomId: nowChatRoomId });
-      }
-      return getChatList();
-    },
+    queryFn: getChatList,
   });
   const { connect, disconnect } = useChatNotification(
     "NEW_CHAT_NOTIFICATION",

--- a/src/components/Chat/ChatRoomList/ChatRoom.jsx
+++ b/src/components/Chat/ChatRoomList/ChatRoom.jsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Typography } from "@material-tailwind/react";
-import { jwtDecode } from "jwt-decode";
 import { getHourAndMinutes } from "../../../utils/date";
 import useChat from "../../../hooks/useChat";
-import { getCookie } from "../../../utils/cookie";
+import { useRecoilValue } from "recoil";
+import { memberIdState } from "../../../recoil/atoms/auth";
 
 export default function ChatRoom({
   chatRoom: { chatRoomId, title, unreadCount, lastMessage, memberCount },
@@ -13,10 +13,11 @@ export default function ChatRoom({
   setChatRooms,
 }) {
   const navigate = useNavigate();
+  const memberId = useRecoilValue(memberIdState);
   const { connect, disconnect } = useChat(
     "CHAT_ROOM_LIST",
     chatRoomId,
-    jwtDecode(getCookie("accessToken")).memberId,
+    memberId,
     (newChat) => {
       const parsedChat = JSON.parse(newChat);
       const index = chatRooms.findIndex(

--- a/src/components/Chat/ChatRoomList/ChatRoom.jsx
+++ b/src/components/Chat/ChatRoomList/ChatRoom.jsx
@@ -1,9 +1,9 @@
 import React, { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Typography } from "@material-tailwind/react";
+import { jwtDecode } from "jwt-decode";
 import { getHourAndMinutes } from "../../../utils/date";
 import useChat from "../../../hooks/useChat";
-import { jwtDecode } from "jwt-decode";
 import { getCookie } from "../../../utils/cookie";
 
 export default function ChatRoom({

--- a/src/components/Chat/ChatRoomList/ChatRoom.jsx
+++ b/src/components/Chat/ChatRoomList/ChatRoom.jsx
@@ -5,6 +5,7 @@ import { getHourAndMinutes } from "../../../utils/date";
 import useChat from "../../../hooks/useChat";
 import { useRecoilValue } from "recoil";
 import { memberIdState } from "../../../recoil/atoms/auth";
+import { disconnectChatRoom } from "../../../apis/chat";
 
 export default function ChatRoom({
   chatRoom: { chatRoomId, title, unreadCount, lastMessage, memberCount },
@@ -45,7 +46,10 @@ export default function ChatRoom({
     }
   );
 
-  const handleClick = () => {
+  const handleClick = async () => {
+    if (nowChatRoomId) {
+      await disconnectChatRoom({ chatRoomId: nowChatRoomId });
+    }
     navigate(`/chatting/${chatRoomId}`);
   };
 

--- a/src/components/Chat/ChatRoomList/ChatRoom.jsx
+++ b/src/components/Chat/ChatRoomList/ChatRoom.jsx
@@ -8,6 +8,7 @@ import { getCookie } from "../../../utils/cookie";
 
 export default function ChatRoom({
   chatRoom: { chatRoomId, title, unreadCount, lastMessage, memberCount },
+  nowChatRoomId,
   chatRooms,
   setChatRooms,
 }) {
@@ -25,7 +26,10 @@ export default function ChatRoom({
       if (index !== -1) {
         const updatedChatRoom = {
           ...chatRooms[index],
-          unreadCount: chatRooms[index].unreadCount + 1,
+          unreadCount:
+            nowChatRoomId === chatRoomId
+              ? chatRooms[index].unreadCount
+              : chatRooms[index].unreadCount + 1,
           lastMessage: {
             ...chatRooms[index].lastMessage,
             sendTime: parsedChat.sendTime,

--- a/src/components/Chat/Chatting/ChatForm.jsx
+++ b/src/components/Chat/Chatting/ChatForm.jsx
@@ -1,9 +1,12 @@
 import React from "react";
 import { Textarea } from "@material-tailwind/react";
 import { useForm } from "react-hook-form";
+import { MdSend } from "react-icons/md";
 import Button from "../../Common/Button";
+import useBreakpoint from "../../../hooks/useBreakPoint";
 
 export default function ChatForm({ sendMessage }) {
+  const { isSmallMobile } = useBreakpoint();
   const {
     register,
     handleSubmit,
@@ -34,21 +37,33 @@ export default function ChatForm({ sendMessage }) {
     reset({ chat: "" });
   };
   return (
-    <form onSubmit={handleSubmit(onSubmit)} onKeyDown={handleKeyDown}>
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      onKeyDown={handleKeyDown}
+      className="relative flex items-start gap-2"
+    >
       <Textarea
-        placeholder=""
-        rows={3}
-        className="border-none font-semibold"
+        rows={isSmallMobile ? 1 : 3}
+        className="pl-4 pr-12 sm:px-3 min-h-full border-none font-semibold text-white !text-base"
         labelProps={{
           className: "hidden",
         }}
         containerProps={{
-          className: "min-w-fit bg-white rounded-[7px]",
+          className:
+            "grid min-w-fit h-full bg-gray-900 border border-blue-gray-900 rounded-full sm:rounded-[7px]",
         }}
         {...register("chat")}
       />
-      <Button type="submit" disabled={!isDirty || !isValid}>
-        전송
+      <Button
+        type="submit"
+        disabled={!isDirty || !isValid}
+        className="absolute sm:relative right-1 top-0 bottom-0 my-auto sm:my-0 p-1 sm:py-3 sm:px-6 bg-transparent sm:bg-brand text-sm shrink-0 transition-none"
+      >
+        {isSmallMobile ? (
+          <MdSend size={26} className="text-brand -rotate-45 " />
+        ) : (
+          <span className="text-white">전송</span>
+        )}
       </Button>
     </form>
   );

--- a/src/components/Chat/Chatting/ChatForm.jsx
+++ b/src/components/Chat/Chatting/ChatForm.jsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { Textarea } from "@material-tailwind/react";
+import { useForm } from "react-hook-form";
+import Button from "../../Common/Button";
+
+export default function ChatForm({ sendMessage }) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    setFocus,
+    formState: { isDirty, isValid },
+  } = useForm({
+    defaultValues: {
+      chat: "",
+    },
+  });
+
+  const handleKeyDown = (e) => {
+    if (
+      e.key === "Enter" &&
+      !e.shiftKey &&
+      e.nativeEvent.isComposing === false
+    ) {
+      e.preventDefault();
+      handleSubmit(onSubmit)();
+    }
+  };
+  const onSubmit = ({ chat }) => {
+    setFocus("chat");
+    if (!chat.trim()) return;
+
+    sendMessage(chat);
+    reset({ chat: "" });
+  };
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} onKeyDown={handleKeyDown}>
+      <Textarea
+        placeholder=""
+        rows={3}
+        className="border-none font-semibold"
+        labelProps={{
+          className: "hidden",
+        }}
+        containerProps={{
+          className: "min-w-fit bg-white rounded-[7px]",
+        }}
+        {...register("chat")}
+      />
+      <Button type="submit" disabled={!isDirty || !isValid}>
+        전송
+      </Button>
+    </form>
+  );
+}

--- a/src/components/Chat/Chatting/ChattingColumn.jsx
+++ b/src/components/Chat/Chatting/ChattingColumn.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { v4 as uuidv4 } from "uuid";
+import { jwtDecode } from "jwt-decode";
+import { CHAT_QUERY_KEYS } from "../../../constants/queryKeys";
+import useChat from "../../../hooks/useChat";
+import { getCookie } from "../../../utils/cookie";
+import { getChattingData } from "../../../apis/chat";
+
+export default function ChattingColumn({ chatRoomId, chatList, setChatList }) {
+  // const [chat, setChat] = useState("");
+  const { error, data } = useQuery({
+    queryKey: CHAT_QUERY_KEYS.chatData(chatRoomId),
+    queryFn: () => getChattingData({ chatRoomId }),
+  });
+
+  const handleChatList = (newChat) => {
+    setChatList((prev) => [...prev, JSON.parse(newChat).content]);
+  };
+  const { connect, disconnect, sendMessage } = useChat(
+    "CHAT_ROOM",
+    chatRoomId,
+    jwtDecode(getCookie("accessToken")).memberId,
+    handleChatList
+  );
+  // const handleChange = (e) => {
+  //   setChat(e.target.value);
+  // };
+
+  useEffect(() => {
+    setChatList(data.messages);
+  }, [data]);
+
+  useEffect(() => {
+    connect();
+
+    return () => disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (error) {
+    return <div>{error.message}</div>;
+  }
+  return (
+    <ul>
+      {chatList.map((chat) => (
+        <li key={uuidv4()}>{chat.content}</li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/Chat/Chatting/ChattingColumn.jsx
+++ b/src/components/Chat/Chatting/ChattingColumn.jsx
@@ -42,8 +42,8 @@ export default function ChattingColumn() {
     return <div>{error.message}</div>;
   }
   return (
-    <article>
-      <ul className="grow">
+    <article className="flex flex-col gap-1 grow pl-4 md:pl-2 pr-4 py-4 max-h-full">
+      <ul className="grow overflow-y-auto">
         {chatList.map((chat) => (
           <li key={uuidv4()}>{chat.content}</li>
         ))}

--- a/src/components/Chat/Chatting/ChattingColumn.jsx
+++ b/src/components/Chat/Chatting/ChattingColumn.jsx
@@ -1,5 +1,6 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useParams } from "react-router-dom";
 import { v4 as uuidv4 } from "uuid";
 import { jwtDecode } from "jwt-decode";
 import { CHAT_QUERY_KEYS } from "../../../constants/queryKeys";
@@ -8,7 +9,9 @@ import { getCookie } from "../../../utils/cookie";
 import { getChattingData } from "../../../apis/chat";
 import ChatForm from "./ChatForm";
 
-export default function ChattingColumn({ chatRoomId, chatList, setChatList }) {
+export default function ChattingColumn() {
+  const { chatRoomId } = useParams();
+  const [chatList, setChatList] = useState([]);
   const { error, data } = useQuery({
     queryKey: CHAT_QUERY_KEYS.chatData(chatRoomId),
     queryFn: () => getChattingData({ chatRoomId }),
@@ -33,7 +36,7 @@ export default function ChattingColumn({ chatRoomId, chatList, setChatList }) {
 
     return () => disconnect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [chatRoomId]);
 
   if (error) {
     return <div>{error.message}</div>;

--- a/src/components/Chat/Chatting/ChattingColumn.jsx
+++ b/src/components/Chat/Chatting/ChattingColumn.jsx
@@ -48,6 +48,7 @@ export default function ChattingColumn() {
   return (
     <article className="flex flex-col gap-1 grow pl-4 md:pl-2 pr-4 py-4 max-h-full">
       <ChattingList
+        memberId={memberId}
         chatRoomId={chatRoomId}
         firstChatData={messages}
         chatList={chatList}

--- a/src/components/Chat/Chatting/ChattingColumn.jsx
+++ b/src/components/Chat/Chatting/ChattingColumn.jsx
@@ -2,12 +2,12 @@ import React, { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
 import { useRecoilValue } from "recoil";
-import { v4 as uuidv4 } from "uuid";
 import { CHAT_QUERY_KEYS } from "../../../constants/queryKeys";
 import useChat from "../../../hooks/useChat";
 import { getChattingData } from "../../../apis/chat";
 import ChatForm from "./ChatForm";
 import { memberIdState } from "../../../recoil/atoms/auth";
+import ChattingList from "./ChattingList";
 
 export default function ChattingColumn() {
   const { chatRoomId } = useParams();
@@ -44,11 +44,11 @@ export default function ChattingColumn() {
   }
   return (
     <article className="flex flex-col gap-1 grow pl-4 md:pl-2 pr-4 py-4 max-h-full">
-      <ul className="grow overflow-y-auto">
-        {chatList.map((chat) => (
-          <li key={uuidv4()}>{chat.content}</li>
-        ))}
-      </ul>
+      <ChattingList
+        chatRoomId={chatRoomId}
+        chatList={chatList}
+        setChatList={setChatList}
+      />
       <ChatForm sendMessage={sendMessage} />
     </article>
   );

--- a/src/components/Chat/Chatting/ChattingColumn.jsx
+++ b/src/components/Chat/Chatting/ChattingColumn.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { v4 as uuidv4 } from "uuid";
 import { jwtDecode } from "jwt-decode";
@@ -6,16 +6,16 @@ import { CHAT_QUERY_KEYS } from "../../../constants/queryKeys";
 import useChat from "../../../hooks/useChat";
 import { getCookie } from "../../../utils/cookie";
 import { getChattingData } from "../../../apis/chat";
+import ChatForm from "./ChatForm";
 
 export default function ChattingColumn({ chatRoomId, chatList, setChatList }) {
-  // const [chat, setChat] = useState("");
   const { error, data } = useQuery({
     queryKey: CHAT_QUERY_KEYS.chatData(chatRoomId),
     queryFn: () => getChattingData({ chatRoomId }),
   });
 
   const handleChatList = (newChat) => {
-    setChatList((prev) => [...prev, JSON.parse(newChat).content]);
+    setChatList((prev) => [...prev, JSON.parse(newChat)]);
   };
   const { connect, disconnect, sendMessage } = useChat(
     "CHAT_ROOM",
@@ -23,13 +23,10 @@ export default function ChattingColumn({ chatRoomId, chatList, setChatList }) {
     jwtDecode(getCookie("accessToken")).memberId,
     handleChatList
   );
-  // const handleChange = (e) => {
-  //   setChat(e.target.value);
-  // };
 
   useEffect(() => {
     setChatList(data.messages);
-  }, [data]);
+  }, [data, setChatList]);
 
   useEffect(() => {
     connect();
@@ -42,10 +39,13 @@ export default function ChattingColumn({ chatRoomId, chatList, setChatList }) {
     return <div>{error.message}</div>;
   }
   return (
-    <ul>
-      {chatList.map((chat) => (
-        <li key={uuidv4()}>{chat.content}</li>
-      ))}
-    </ul>
+    <article>
+      <ul className="grow">
+        {chatList.map((chat) => (
+          <li key={uuidv4()}>{chat.content}</li>
+        ))}
+      </ul>
+      <ChatForm sendMessage={sendMessage} />
+    </article>
   );
 }

--- a/src/components/Chat/Chatting/ChattingColumn.jsx
+++ b/src/components/Chat/Chatting/ChattingColumn.jsx
@@ -13,7 +13,10 @@ export default function ChattingColumn() {
   const { chatRoomId } = useParams();
   const [chatList, setChatList] = useState([]);
   const memberId = useRecoilValue(memberIdState);
-  const { error, data } = useQuery({
+  const {
+    error,
+    data: { messages, unreadCount },
+  } = useQuery({
     queryKey: CHAT_QUERY_KEYS.chatData(chatRoomId),
     queryFn: () => getChattingData({ chatRoomId }),
   });
@@ -29,8 +32,8 @@ export default function ChattingColumn() {
   );
 
   useEffect(() => {
-    setChatList(data.messages);
-  }, [data, setChatList]);
+    setChatList(messages);
+  }, [messages, setChatList]);
 
   useEffect(() => {
     connect();
@@ -46,8 +49,10 @@ export default function ChattingColumn() {
     <article className="flex flex-col gap-1 grow pl-4 md:pl-2 pr-4 py-4 max-h-full">
       <ChattingList
         chatRoomId={chatRoomId}
+        firstChatData={messages}
         chatList={chatList}
         setChatList={setChatList}
+        unreadCount={unreadCount}
       />
       <ChatForm sendMessage={sendMessage} />
     </article>

--- a/src/components/Chat/Chatting/ChattingColumn.jsx
+++ b/src/components/Chat/Chatting/ChattingColumn.jsx
@@ -1,17 +1,18 @@
 import React, { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
+import { useRecoilValue } from "recoil";
 import { v4 as uuidv4 } from "uuid";
-import { jwtDecode } from "jwt-decode";
 import { CHAT_QUERY_KEYS } from "../../../constants/queryKeys";
 import useChat from "../../../hooks/useChat";
-import { getCookie } from "../../../utils/cookie";
 import { getChattingData } from "../../../apis/chat";
 import ChatForm from "./ChatForm";
+import { memberIdState } from "../../../recoil/atoms/auth";
 
 export default function ChattingColumn() {
   const { chatRoomId } = useParams();
   const [chatList, setChatList] = useState([]);
+  const memberId = useRecoilValue(memberIdState);
   const { error, data } = useQuery({
     queryKey: CHAT_QUERY_KEYS.chatData(chatRoomId),
     queryFn: () => getChattingData({ chatRoomId }),
@@ -23,7 +24,7 @@ export default function ChattingColumn() {
   const { connect, disconnect, sendMessage } = useChat(
     "CHAT_ROOM",
     chatRoomId,
-    jwtDecode(getCookie("accessToken")).memberId,
+    memberId,
     handleChatList
   );
 

--- a/src/components/Chat/Chatting/ChattingItem.jsx
+++ b/src/components/Chat/Chatting/ChattingItem.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+export default function ChattingItem({
+  chatListRef,
+  chat: { content, senderId, sendTime },
+  index,
+}) {
+  return (
+    <li
+      ref={(element) => {
+        chatListRef.current[index] = element;
+      }}
+    >
+      <span>{content}</span>
+      <span className="ml-20">{senderId}</span>
+    </li>
+  );
+}

--- a/src/components/Chat/Chatting/ChattingList.jsx
+++ b/src/components/Chat/Chatting/ChattingList.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useRef } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { CHAT_QUERY_KEYS } from "../../../constants/queryKeys";
@@ -6,6 +6,7 @@ import useIntersectionObserver from "../../../hooks/useIntersectionObserver";
 import { getChattingWithCursor } from "../../../apis/chat";
 import { Spinner } from "@material-tailwind/react";
 import ChattingItem from "./ChattingItem";
+import { queryClient } from "../../../apis/queryClient";
 
 export default function ChattingList({
   chatRoomId,
@@ -17,6 +18,7 @@ export default function ChattingList({
   const observerRef = useRef(null);
   const chatListContainerRef = useRef(null);
   const chatListRef = useRef([]);
+  const [prevScrollHeight, setPrevScrollHeight] = useState(0);
   const { fetchNextPage, hasNextPage, isFetchingNextPage, data, error } =
     useInfiniteQuery({
       queryKey: CHAT_QUERY_KEYS.chatDataWithCursor(chatRoomId),
@@ -29,7 +31,21 @@ export default function ChattingList({
       getNextPageParam: (lastPage) =>
         lastPage.messages.length > 0 ? lastPage.messages[0].sendTime : null,
     });
-  const [observe, unobserve] = useIntersectionObserver(fetchNextPage);
+  const [observe, unobserve] = useIntersectionObserver(() => {
+    fetchNextPage();
+    const scrollHeight = chatListContainerRef.current?.scrollHeight;
+    setPrevScrollHeight(scrollHeight);
+  });
+
+  useLayoutEffect(() => {
+    if (!prevScrollHeight) return;
+
+    const scrollHeight = chatListContainerRef.current.scrollHeight;
+    chatListContainerRef.current.scrollTo({
+      top: scrollHeight - prevScrollHeight,
+    });
+    return () => setPrevScrollHeight(0);
+  }, [chatList, prevScrollHeight]);
 
   useLayoutEffect(() => {
     if (chatList.length === 0 || firstChatData.length !== chatList.length)
@@ -40,6 +56,7 @@ export default function ChattingList({
     });
   }, [chatList, unreadCount, firstChatData]);
 
+  // hasNextPage 넣어서 테스트
   useEffect(() => {
     const dataLength = data.pages.length;
     if (dataLength === 1) return;
@@ -54,6 +71,10 @@ export default function ChattingList({
 
     return () => unobserve(observer);
   }, [observerRef, hasNextPage, observe, unobserve]);
+
+  useEffect(() => {
+    queryClient.removeQueries(CHAT_QUERY_KEYS.chatDataWithCursor(chatRoomId));
+  }, [chatRoomId]);
 
   if (error) {
     return <div>{error.message}</div>;

--- a/src/components/Chat/Chatting/ChattingList.jsx
+++ b/src/components/Chat/Chatting/ChattingList.jsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useRef } from "react";
+import { v4 as uuidv4 } from "uuid";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { CHAT_QUERY_KEYS } from "../../../constants/queryKeys";
+import useIntersectionObserver from "../../../hooks/useIntersectionObserver";
+import { getChattingWithCursor } from "../../../apis/chat";
+import { Spinner } from "@material-tailwind/react";
+
+export default function ChattingList({ chatRoomId, chatList, setChatList }) {
+  const observerRef = useRef(null);
+  const { fetchNextPage, hasNextPage, isFetchingNextPage, data, error } =
+    useInfiniteQuery({
+      queryKey: CHAT_QUERY_KEYS.chatDataWithCursor(chatRoomId),
+      queryFn: ({ pageParam }) =>
+        getChattingWithCursor({
+          chatRoomId,
+          cursor: pageParam,
+        }),
+      initialPageParam: new Date().toISOString(),
+      getNextPageParam: (lastPage) =>
+        lastPage.messages.length > 0 ? lastPage.messages[0].sendTime : null,
+    });
+  const [observe, unobserve] = useIntersectionObserver(fetchNextPage);
+
+  useEffect(() => {
+    const lastIndex = data.pages.length - 1;
+    if (data.pageParams.length === 1 || !hasNextPage) return;
+
+    setChatList((prev) => [...data.pages[lastIndex].messages, ...prev]);
+  }, [data, setChatList, hasNextPage]);
+
+  useEffect(() => {
+    if (!hasNextPage || !observerRef) return;
+    const observer = observerRef.current;
+    observe(observer);
+
+    return () => unobserve(observer);
+  }, [observerRef, hasNextPage, observe, unobserve]);
+
+  if (error) {
+    return <div>{error.message}</div>;
+  }
+  return (
+    <ul className="grow overflow-y-auto">
+      <div ref={observerRef} className="flex justify-center items-center">
+        {isFetchingNextPage && <Spinner className="h-8 w-8 text-brand" />}
+      </div>
+      {chatList.map((chat) => (
+        <li key={uuidv4()}>
+          <span>{chat.content}</span>
+          <span className="ml-20">{chat.senderId}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/Chat/Chatting/ChattingList.jsx
+++ b/src/components/Chat/Chatting/ChattingList.jsx
@@ -48,15 +48,18 @@ export default function ChattingList({
   }, [chatList, prevScrollHeight]);
 
   useLayoutEffect(() => {
-    if (chatList.length === 0 || firstChatData.length !== chatList.length)
+    if (
+      chatList.length === 0 ||
+      firstChatData.length !== chatList.length ||
+      !hasNextPage
+    )
       return;
 
     chatListRef.current[chatList.length - 1 - unreadCount]?.scrollIntoView({
       block: "center",
     });
-  }, [chatList, unreadCount, firstChatData]);
+  }, [chatList, unreadCount, firstChatData, hasNextPage]);
 
-  // hasNextPage 넣어서 테스트
   useEffect(() => {
     const dataLength = data.pages.length;
     if (dataLength === 1) return;

--- a/src/components/Chat/Chatting/ChattingList.jsx
+++ b/src/components/Chat/Chatting/ChattingList.jsx
@@ -9,6 +9,7 @@ import ChattingItem from "./ChattingItem";
 import { queryClient } from "../../../apis/queryClient";
 
 export default function ChattingList({
+  memberId,
   chatRoomId,
   firstChatData,
   chatList,
@@ -38,6 +39,28 @@ export default function ChattingList({
   });
 
   useLayoutEffect(() => {
+    if (
+      chatList.length === 0 ||
+      chatList.length === firstChatData.length ||
+      prevScrollHeight
+    )
+      return;
+
+    const { scrollTop, scrollHeight, clientHeight } =
+      chatListContainerRef.current;
+    if (
+      chatList[chatList.length - 1].senderId === memberId ||
+      scrollHeight - scrollTop - clientHeight < 500
+    ) {
+      chatListRef.current[chatList.length - 1]?.scrollIntoView({
+        block: "end",
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chatList, firstChatData, memberId]);
+
+  // 추가 데이터가 가져올 때 스크롤 위치 고정
+  useLayoutEffect(() => {
     if (!prevScrollHeight) return;
 
     const scrollHeight = chatListContainerRef.current.scrollHeight;
@@ -47,6 +70,8 @@ export default function ChattingList({
     return () => setPrevScrollHeight(0);
   }, [chatList, prevScrollHeight]);
 
+  // 첫 렌더링 시 읽지 않은 채팅이 가운데 보이게 스크롤
+  // 읽지 않은 채팅이 없으면 가장 아래로 스크롤
   useLayoutEffect(() => {
     if (
       chatList.length === 0 ||

--- a/src/components/Chat/Chatting/ChattingList.jsx
+++ b/src/components/Chat/Chatting/ChattingList.jsx
@@ -5,9 +5,11 @@ import { CHAT_QUERY_KEYS } from "../../../constants/queryKeys";
 import useIntersectionObserver from "../../../hooks/useIntersectionObserver";
 import { getChattingWithCursor } from "../../../apis/chat";
 import { Spinner } from "@material-tailwind/react";
+import ChattingItem from "./ChattingItem";
 
 export default function ChattingList({ chatRoomId, chatList, setChatList }) {
   const observerRef = useRef(null);
+  const chatListRef = useRef([]);
   const { fetchNextPage, hasNextPage, isFetchingNextPage, data, error } =
     useInfiniteQuery({
       queryKey: CHAT_QUERY_KEYS.chatDataWithCursor(chatRoomId),
@@ -45,11 +47,13 @@ export default function ChattingList({ chatRoomId, chatList, setChatList }) {
       <div ref={observerRef} className="flex justify-center items-center">
         {isFetchingNextPage && <Spinner className="h-8 w-8 text-brand" />}
       </div>
-      {chatList.map((chat) => (
-        <li key={uuidv4()}>
-          <span>{chat.content}</span>
-          <span className="ml-20">{chat.senderId}</span>
-        </li>
+      {chatList.map((chat, index) => (
+        <ChattingItem
+          key={uuidv4()}
+          chatListRef={chatListRef}
+          chat={chat}
+          index={index}
+        />
       ))}
     </ul>
   );

--- a/src/components/Chat/Chatting/ChattingList.jsx
+++ b/src/components/Chat/Chatting/ChattingList.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useLayoutEffect, useRef } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { CHAT_QUERY_KEYS } from "../../../constants/queryKeys";
@@ -7,8 +7,15 @@ import { getChattingWithCursor } from "../../../apis/chat";
 import { Spinner } from "@material-tailwind/react";
 import ChattingItem from "./ChattingItem";
 
-export default function ChattingList({ chatRoomId, chatList, setChatList }) {
+export default function ChattingList({
+  chatRoomId,
+  firstChatData,
+  chatList,
+  setChatList,
+  unreadCount,
+}) {
   const observerRef = useRef(null);
+  const chatListContainerRef = useRef(null);
   const chatListRef = useRef([]);
   const { fetchNextPage, hasNextPage, isFetchingNextPage, data, error } =
     useInfiniteQuery({
@@ -24,12 +31,21 @@ export default function ChattingList({ chatRoomId, chatList, setChatList }) {
     });
   const [observe, unobserve] = useIntersectionObserver(fetchNextPage);
 
-  useEffect(() => {
-    const lastIndex = data.pages.length - 1;
-    if (data.pageParams.length === 1 || !hasNextPage) return;
+  useLayoutEffect(() => {
+    if (chatList.length === 0 || firstChatData.length !== chatList.length)
+      return;
 
-    setChatList((prev) => [...data.pages[lastIndex].messages, ...prev]);
-  }, [data, setChatList, hasNextPage]);
+    chatListRef.current[chatList.length - 1 - unreadCount]?.scrollIntoView({
+      block: "center",
+    });
+  }, [chatList, unreadCount, firstChatData]);
+
+  useEffect(() => {
+    const dataLength = data.pages.length;
+    if (dataLength === 1) return;
+
+    setChatList((prev) => [...data.pages[dataLength - 1].messages, ...prev]);
+  }, [data, setChatList]);
 
   useEffect(() => {
     if (!hasNextPage || !observerRef) return;
@@ -43,7 +59,7 @@ export default function ChattingList({ chatRoomId, chatList, setChatList }) {
     return <div>{error.message}</div>;
   }
   return (
-    <ul className="grow overflow-y-auto">
+    <ul ref={chatListContainerRef} className="grow overflow-y-auto">
       <div ref={observerRef} className="flex justify-center items-center">
         {isFetchingNextPage && <Spinner className="h-8 w-8 text-brand" />}
       </div>

--- a/src/components/Chat/Chatting/ChattingPageMain.jsx
+++ b/src/components/Chat/Chatting/ChattingPageMain.jsx
@@ -1,16 +1,20 @@
 import React, { useState } from "react";
 import ChattingColumn from "./ChattingColumn";
+import ChatListPageMain from "../ChatRoomList/ChatListPageMain";
 
 export default function ChattingPageMain({ chatRoomId }) {
   const [chatList, setChatList] = useState([]);
 
   return (
-    <div>
+    <>
+      <section className="w-80">
+        <ChatListPageMain />
+      </section>
       <ChattingColumn
         chatRoomId={chatRoomId}
         chatList={chatList}
         setChatList={setChatList}
       />
-    </div>
+    </>
   );
 }

--- a/src/components/Chat/Chatting/ChattingPageMain.jsx
+++ b/src/components/Chat/Chatting/ChattingPageMain.jsx
@@ -1,20 +1,14 @@
-import React, { useState } from "react";
+import React from "react";
 import ChattingColumn from "./ChattingColumn";
 import ChatListPageMain from "../ChatRoomList/ChatListPageMain";
 
-export default function ChattingPageMain({ chatRoomId }) {
-  const [chatList, setChatList] = useState([]);
-
+export default function ChattingPageMain() {
   return (
     <>
-      <section className="w-80">
+      <section className="max-w-xs w-full w-">
         <ChatListPageMain />
       </section>
-      <ChattingColumn
-        chatRoomId={chatRoomId}
-        chatList={chatList}
-        setChatList={setChatList}
-      />
+      <ChattingColumn />
     </>
   );
 }

--- a/src/components/Chat/Chatting/ChattingPageMain.jsx
+++ b/src/components/Chat/Chatting/ChattingPageMain.jsx
@@ -1,67 +1,16 @@
-import React, { useEffect, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { CHAT_QUERY_KEYS } from "../../../constants/queryKeys";
-import { getChattingData } from "../../../apis/chat";
-import useChat from "../../../hooks/useChat";
-import { jwtDecode } from "jwt-decode";
-import { getCookie } from "../../../utils/cookie";
+import React, { useState } from "react";
+import ChattingColumn from "./ChattingColumn";
 
 export default function ChattingPageMain({ chatRoomId }) {
-  const [chat, setChat] = useState("");
   const [chatList, setChatList] = useState([]);
-  const { error, data } = useQuery({
-    queryKey: CHAT_QUERY_KEYS.chatData(chatRoomId),
-    queryFn: () => getChattingData({ chatRoomId }),
-  });
 
-  const handleChatList = (newChat) => {
-    setChatList((prev) => [...prev, JSON.parse(newChat).content]);
-  };
-  const { connect, disconnect, sendMessage } = useChat(
-    "CHAT_ROOM",
-    chatRoomId,
-    jwtDecode(getCookie("accessToken")).memberId,
-    handleChatList
-  );
-
-  const handleChange = (e) => {
-    setChat(e.target.value);
-  };
-  const handleClick = () => {
-    sendMessage(chat);
-    setChat("");
-  };
-
-  useEffect(() => {
-    connect();
-
-    return () => disconnect();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  useEffect(() => {
-    if (data) {
-      setChatList(data.messages.map((chat) => chat.content));
-    }
-  }, [data]);
-
-  if (error) {
-    return <div>{error.message}</div>;
-  }
   return (
     <div>
-      <ul>
-        {chatList.map((chat, index) => (
-          <li key={index}>{chat}</li>
-        ))}
-      </ul>
-      <input
-        className="text-black"
-        type="text"
-        value={chat}
-        onChange={handleChange}
+      <ChattingColumn
+        chatRoomId={chatRoomId}
+        chatList={chatList}
+        setChatList={setChatList}
       />
-      <button onClick={handleClick}>submit</button>
     </div>
   );
 }

--- a/src/components/Chat/Chatting/ChattingPageMain.jsx
+++ b/src/components/Chat/Chatting/ChattingPageMain.jsx
@@ -5,7 +5,7 @@ import ChatListPageMain from "../ChatRoomList/ChatListPageMain";
 export default function ChattingPageMain() {
   return (
     <>
-      <section className="max-w-xs w-full w-">
+      <section className="hidden md:block max-w-xs w-full">
         <ChatListPageMain />
       </section>
       <ChattingColumn />

--- a/src/components/Common/Header/Header.jsx
+++ b/src/components/Common/Header/Header.jsx
@@ -5,7 +5,7 @@ import { Drawer, List } from "@material-tailwind/react";
 import { MdMenu, MdClose, MdLogin } from "react-icons/md";
 import { v4 as uuidv4 } from "uuid";
 import Button from "../Button";
-import isLoggedInState from "../../../recoil/atoms/auth";
+import { isLoggedInState, memberIdState } from "../../../recoil/atoms/auth";
 import NavMenu from "./NavMenu";
 import Logo from "../Image/Logo";
 import { removeCookie } from "../../../utils/cookie";
@@ -26,10 +26,12 @@ export default function Header() {
   const { pathname } = useLocation();
   const [isOpen, setIsOpen] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useRecoilState(isLoggedInState);
+  const setMemberId = useSetRecoilState(memberIdState);
   const setCreateNewChat = useSetRecoilState(createNewChatState);
 
   const handleLogoutClick = () => {
     setIsLoggedIn(false);
+    setMemberId(null);
     setCreateNewChat(false);
     removeCookie("accessToken", { path: "/" });
     navigate("/");

--- a/src/components/Common/Modal/NewChatTitleModal.jsx
+++ b/src/components/Common/Modal/NewChatTitleModal.jsx
@@ -28,8 +28,8 @@ export default function NewChatTitleModal({ isOpen, onClick }) {
   );
   const createChatRoomMutate = useMutation({
     mutationFn: createChatRoom,
-    onSuccess: () => {
-      navigate("/chatList");
+    onSuccess: (response) => {
+      navigate(`/chatting/${response.chatRoomId}`);
       setNewChatMembers([]);
       setCreateNewChat(false);
     },

--- a/src/components/Login/LoginPageMain.jsx
+++ b/src/components/Login/LoginPageMain.jsx
@@ -2,17 +2,19 @@ import React, { useEffect } from "react";
 import { useParams, useSearchParams, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { useSetRecoilState } from "recoil";
-import isLoggedInState from "../../recoil/atoms/auth";
+import { isLoggedInState, memberIdState } from "../../recoil/atoms/auth";
 import { login } from "../../apis/auth";
 import { setCookie } from "../../utils/cookie";
 import LoginLoading from "./LoginLoading";
 import { AUTH_QUERY_KEYS } from "../../constants/queryKeys";
+import { jwtDecode } from "jwt-decode";
 
 export default function LoginPageMain() {
   const navigate = useNavigate();
   const { provider } = useParams();
   const [searchParams] = useSearchParams();
   const setIsLoggedIn = useSetRecoilState(isLoggedInState);
+  const setMemberId = useSetRecoilState(memberIdState);
   const { data } = useQuery({
     queryKey: AUTH_QUERY_KEYS.login,
     queryFn: () => login({ code: searchParams.get("code"), provider }),
@@ -27,6 +29,7 @@ export default function LoginPageMain() {
         path: "/",
         expires: new Date(refreshTokenExpirationInMilliSeconds),
       });
+      setMemberId(jwtDecode(accessToken).memberId);
 
       if (firstLogin) {
         navigate("/profile");
@@ -34,7 +37,7 @@ export default function LoginPageMain() {
         navigate("/");
       }
     }
-  }, [data, setIsLoggedIn, navigate]);
+  }, [data, setIsLoggedIn, setMemberId, navigate]);
 
   return <LoginLoading />;
 }

--- a/src/constants/queryKeys.js
+++ b/src/constants/queryKeys.js
@@ -12,5 +12,6 @@ export const PROFILE_QUERY_KEYS = {
 
 export const CHAT_QUERY_KEYS = {
   chatList: ["chatList"],
-  chatData: (id) => ["chatDatat", id],
+  chatData: (chatRoomId) => ["chatData", chatRoomId],
+  chatDataWithCursor: (chatRoomId) => ["chatDataWithCursor", chatRoomId],
 };

--- a/src/constants/recoilKeys.js
+++ b/src/constants/recoilKeys.js
@@ -1,5 +1,6 @@
 export const AUTH_RECOIL_KEYS = {
   isLoggedIn: "isLoggedIn",
+  memberId: "memberId",
 };
 
 export const FILTER_RECOIL_KEYS = {

--- a/src/hooks/useBreakPoint.jsx
+++ b/src/hooks/useBreakPoint.jsx
@@ -1,0 +1,28 @@
+import { useState, useEffect } from "react";
+
+export default function useBreakpoint() {
+  const [isSmallMobile, setIsSmallMobile] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+  const [isTablet, setIsTablet] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const screenWidth = window.innerWidth;
+      setIsSmallMobile(screenWidth < 640);
+      setIsMobile(screenWidth >= 640 && screenWidth < 768);
+      setIsTablet(screenWidth >= 768 && screenWidth < 1024);
+      setIsDesktop(screenWidth >= 1024);
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    handleResize();
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  return { isSmallMobile, isMobile, isTablet, isDesktop };
+}

--- a/src/pages/ChattingPage.jsx
+++ b/src/pages/ChattingPage.jsx
@@ -1,15 +1,12 @@
 import React, { Suspense } from "react";
-import { useParams } from "react-router-dom";
 import ChattingPageMain from "../components/Chat/Chatting/ChattingPageMain";
 import Loader from "../components/Common/Loader";
 
 export default function ChattingPage() {
-  const { chatRoomId } = useParams();
-
   return (
     <main className="flex">
       <Suspense fallback={<Loader />}>
-        <ChattingPageMain chatRoomId={chatRoomId} />
+        <ChattingPageMain />
       </Suspense>
     </main>
   );

--- a/src/pages/ChattingPage.jsx
+++ b/src/pages/ChattingPage.jsx
@@ -4,7 +4,7 @@ import Loader from "../components/Common/Loader";
 
 export default function ChattingPage() {
   return (
-    <main className="flex">
+    <main className="block md:flex h-[calc(100vh-3.5rem)] sm:h-[calc(100vh-5rem)]">
       <Suspense fallback={<Loader />}>
         <ChattingPageMain />
       </Suspense>

--- a/src/pages/ChattingPage.jsx
+++ b/src/pages/ChattingPage.jsx
@@ -7,7 +7,7 @@ export default function ChattingPage() {
   const { chatRoomId } = useParams();
 
   return (
-    <main>
+    <main className="flex">
       <Suspense fallback={<Loader />}>
         <ChattingPageMain chatRoomId={chatRoomId} />
       </Suspense>

--- a/src/recoil/atoms/auth.js
+++ b/src/recoil/atoms/auth.js
@@ -1,10 +1,16 @@
 import { atom } from "recoil";
+import { jwtDecode } from "jwt-decode";
 import { getCookie } from "../../utils/cookie";
 import { AUTH_RECOIL_KEYS } from "../../constants/recoilKeys";
 
-const isLoggedInState = atom({
+export const isLoggedInState = atom({
   key: AUTH_RECOIL_KEYS.isLoggedIn,
   default: Boolean(getCookie("accessToken")),
 });
 
-export default isLoggedInState;
+export const memberIdState = atom({
+  key: AUTH_RECOIL_KEYS.memberId,
+  default: getCookie("accessToken")
+    ? jwtDecode(getCookie("accessToken")).memberId
+    : null,
+});


### PR DESCRIPTION
## ⭐Key Changes
1. 채팅 페이지 접근 시 최초 100개의 채팅 데이터를 받아오는 API와 무한 스크롤을 이용해서 채팅을 추가로 받아오는 API 호출
* 최초 데이터를 받고 이후에 사용자로 인한 추가 채팅은 백엔드에서 받아오지 않고 관리하기 위해 채팅 데이터를 state(chatList)로 관리.
* 무한 스크롤로 받아오는 데이터의 최초 데이터 100개는 중복되기 때문에 state에 추가하지 않음.

2. 각각의 상황에 맞게 화면 스크롤 전환
* 최초 렌더링 시 읽지 않은 채팅의 개수에 맞게 읽지 않은 채팅 중 첫 번째 채팅이 화면 가운데 위치하게 스크롤
* 본인이 채팅 시 채팅이 추가되며 최하단으로 스크롤
* 상대방이 채팅 시 일정 스크롤(500px) 이상 올라가 있으면 아래로 스크롤되지 않고, 일정 스크롤 이하에 있으면 최하단으로 스크롤
* 무한 스크롤로 추가 데이터를 받아올 때 스크롤 위치 고정(데이터를 추가하기 전 스크롤 위치를 이용해서 받아온 뒤 그 위치로 스크롤)

3. 채팅방 변경 시 `useInfiniteQuery`의 cache로 인해 데이터가 정상적으로 불러와지지 않는 문제 해결을 위해 채팅방 변경 시 해당 채팅방 ID에 저장된 cache 삭제


