### PR TITLE
채팅페이지 UI구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,21 @@
 import { Spinner } from "@material-tailwind/react";
-import { Suspense } from "react";
+import { Suspense, useEffect } from "react";
 import { QueryErrorResetBoundary } from "@tanstack/react-query";
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import ErrorBoundary from "./components/Error/ErrorBoundary";
 import GlobalErrorFallback from "./components/Common/GlobalErrorFallback";
+import { useSetRecoilState } from "recoil";
+import prevChatRoomIdState from "./recoil/atoms/chatRoomId";
 
 function App() {
+  const location = useLocation();
+  const setPrevChatRoomId = useSetRecoilState(prevChatRoomIdState);
+
+  useEffect(() => {
+    if (location.pathname !== "/chatList") {
+      setPrevChatRoomId(null);
+    }
+  }, [location, setPrevChatRoomId]);
   return (
     <Suspense fallback={<Spinner />}>
       <QueryErrorResetBoundary>

--- a/src/apis/chat.js
+++ b/src/apis/chat.js
@@ -29,3 +29,8 @@ export const disconnectChatRoom = ({ chatRoomId }) =>
   instance
     .get(`${ENDPOINT}/leave`, { params: { chatRoomId } })
     .then((response) => response.data);
+
+export const exitChatRoom = ({ chatRoomId }) =>
+  instance
+    .get(`${ENDPOINT}/exit`, { params: { chatRoomId } })
+    .then((response) => response.data);

--- a/src/components/Chat/ChatRoomList/ChatListPageMain.jsx
+++ b/src/components/Chat/ChatRoomList/ChatListPageMain.jsx
@@ -61,7 +61,7 @@ export default function ChatListPageMain() {
   return chatRooms.length === 0 ? (
     <NullChatList />
   ) : (
-    <Card className="my-4 w-full max-w-2xl bg-light_black">
+    <Card className="my-4 w-full max-w-2xl max-h-full h-full bg-light_black overflow-y-auto">
       <List>
         {chatRooms.map((chatRoom) => (
           <ChatRoom

--- a/src/components/Chat/ChatRoomList/ChatListPageMain.jsx
+++ b/src/components/Chat/ChatRoomList/ChatListPageMain.jsx
@@ -61,7 +61,11 @@ export default function ChatListPageMain() {
   return chatRooms.length === 0 ? (
     <NullChatList />
   ) : (
-    <Card className="my-4 w-full max-w-2xl max-h-full h-full bg-light_black overflow-y-auto">
+    <Card
+      className={`${
+        nowChatRoomId ? "pb-2" : "my-4"
+      } w-full max-w-2xl max-h-full h-full bg-light_black overflow-y-auto`}
+    >
       <List>
         {chatRooms.map((chatRoom) => (
           <ChatRoom

--- a/src/components/Chat/ChatRoomList/ChatListPageMain.jsx
+++ b/src/components/Chat/ChatRoomList/ChatListPageMain.jsx
@@ -38,8 +38,6 @@ export default function ChatListPageMain() {
   );
 
   useEffect(() => {
-    if (chatRoomList.length === 0) return;
-
     setChatRooms(chatRoomList);
   }, [chatRoomList]);
 

--- a/src/components/Chat/ChatRoomList/ChatListPageMain.jsx
+++ b/src/components/Chat/ChatRoomList/ChatListPageMain.jsx
@@ -4,23 +4,30 @@ import { useParams } from "react-router-dom";
 import { Card, List } from "@material-tailwind/react";
 import { v4 as uuidv4 } from "uuid";
 import { CHAT_QUERY_KEYS } from "../../../constants/queryKeys";
-import { getChatList } from "../../../apis/chat";
+import { disconnectChatRoom, getChatList } from "../../../apis/chat";
 import ChatRoom from "./ChatRoom";
 import NullChatList from "./NullChatList";
 import useChatNotification from "../../../hooks/useChatNotification";
 import { useRecoilValue } from "recoil";
 import { memberIdState } from "../../../recoil/atoms/auth";
+import prevChatRoomIdState from "../../../recoil/atoms/chatRoomId";
 
 export default function ChatListPageMain() {
   const { chatRoomId: nowChatRoomId } = useParams();
   const [chatRooms, setChatRooms] = useState([]);
   const memberId = useRecoilValue(memberIdState);
+  const prevChatRoomId = useRecoilValue(prevChatRoomIdState);
   const {
     data: { chatRoomList },
     error,
   } = useQuery({
     queryKey: CHAT_QUERY_KEYS.chatList,
-    queryFn: getChatList,
+    queryFn: async () => {
+      if (prevChatRoomId) {
+        await disconnectChatRoom({ chatRoomId: prevChatRoomId });
+      }
+      return getChatList();
+    },
   });
   const { connect, disconnect } = useChatNotification(
     "NEW_CHAT_NOTIFICATION",

--- a/src/components/Chat/ChatRoomList/ChatRoom.jsx
+++ b/src/components/Chat/ChatRoomList/ChatRoom.jsx
@@ -83,7 +83,7 @@ export default function ChatRoom({
         </Typography>
         {unreadCount !== 0 && (
           <div className="relative grid items-center font-bold uppercase whitespace-nowrap select-none text-white py-1 px-2 text-xs rounded-md bg-brand">
-            <span>{unreadCount}</span>
+            <span>{unreadCount > 100 ? "100+" : unreadCount}</span>
           </div>
         )}
       </div>

--- a/src/components/Chat/ChatRoomList/ChatRoom.jsx
+++ b/src/components/Chat/ChatRoomList/ChatRoom.jsx
@@ -1,11 +1,12 @@
 import React, { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { useRecoilValue } from "recoil";
 import { Typography } from "@material-tailwind/react";
 import { getHourAndMinutes } from "../../../utils/date";
 import useChat from "../../../hooks/useChat";
-import { useRecoilValue } from "recoil";
 import { memberIdState } from "../../../recoil/atoms/auth";
 import { disconnectChatRoom } from "../../../apis/chat";
+import ChatRoomSettingButton from "./ChatRoomSettingButton";
 
 export default function ChatRoom({
   chatRoom: { chatRoomId, title, unreadCount, lastMessage, memberCount },
@@ -73,9 +74,12 @@ export default function ChatRoom({
             {memberCount}
           </Typography>
         </div>
-        <Typography variant="small" className="font-normal">
-          {getHourAndMinutes(new Date(lastMessage.sendTime))}
-        </Typography>
+        <div className="relative flex gap-2">
+          <Typography variant="small" className="font-normal">
+            {getHourAndMinutes(new Date(lastMessage.sendTime))}
+          </Typography>
+          <ChatRoomSettingButton />
+        </div>
       </div>
       <div className="flex justify-between items-center w-full">
         <Typography variant="paragraph" className="mr-2 font-normal truncate">

--- a/src/components/Chat/ChatRoomList/ChatRoom.jsx
+++ b/src/components/Chat/ChatRoomList/ChatRoom.jsx
@@ -78,7 +78,10 @@ export default function ChatRoom({
           <Typography variant="small" className="font-normal">
             {getHourAndMinutes(new Date(lastMessage.sendTime))}
           </Typography>
-          <ChatRoomSettingButton />
+          <ChatRoomSettingButton
+            chatRoomId={chatRoomId}
+            nowChatRoomId={nowChatRoomId}
+          />
         </div>
       </div>
       <div className="flex justify-between items-center w-full">

--- a/src/components/Chat/ChatRoomList/ChatRoomSettingButton.jsx
+++ b/src/components/Chat/ChatRoomList/ChatRoomSettingButton.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { MdOutlineMoreVert, MdExitToApp } from "react-icons/md";
+import {
+  Typography,
+  Menu,
+  MenuHandler,
+  MenuList,
+  MenuItem,
+  Button,
+} from "@material-tailwind/react";
+
+export default function ChatRoomSettingButton() {
+  return (
+    <Menu placement="bottom-end">
+      <MenuHandler>
+        <Button
+          ripple={false}
+          variant="text"
+          className="p-0 text-white hover:text-blue-gray-400 duration-150"
+        >
+          <MdOutlineMoreVert size={20} />
+        </Button>
+      </MenuHandler>
+      <MenuList className="p-1">
+        <MenuItem className="flex items-center gap-2 p-2">
+          <MdExitToApp size={20} />
+          <Typography variant="h6">나가기</Typography>
+        </MenuItem>
+      </MenuList>
+    </Menu>
+  );
+}

--- a/src/components/Chat/ChatRoomList/ChatRoomSettingButton.jsx
+++ b/src/components/Chat/ChatRoomList/ChatRoomSettingButton.jsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { MdOutlineMoreVert, MdExitToApp } from "react-icons/md";
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
 import {
   Typography,
   Menu,
@@ -8,8 +10,26 @@ import {
   MenuItem,
   Button,
 } from "@material-tailwind/react";
+import { exitChatRoom } from "../../../apis/chat";
+import { queryClient } from "../../../apis/queryClient";
+import { CHAT_QUERY_KEYS } from "../../../constants/queryKeys";
 
-export default function ChatRoomSettingButton() {
+export default function ChatRoomSettingButton({ chatRoomId, nowChatRoomId }) {
+  const navigate = useNavigate();
+  const chatRoomSettingMutate = useMutation({
+    mutationFn: () => exitChatRoom({ chatRoomId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: CHAT_QUERY_KEYS.chatList });
+      if (chatRoomId === nowChatRoomId) {
+        navigate("/chatList", { replace: true });
+      }
+    },
+  });
+
+  const handleClick = (e) => {
+    e.stopPropagation();
+    chatRoomSettingMutate.mutate({ chatRoomId });
+  };
   return (
     <Menu placement="bottom-end">
       <MenuHandler>
@@ -22,7 +42,10 @@ export default function ChatRoomSettingButton() {
         </Button>
       </MenuHandler>
       <MenuList className="p-1">
-        <MenuItem className="flex items-center gap-2 p-2">
+        <MenuItem
+          className="flex items-center gap-2 p-2 hover:!text-red-700"
+          onClick={handleClick}
+        >
           <MdExitToApp size={20} />
           <Typography variant="h6">나가기</Typography>
         </MenuItem>

--- a/src/components/Chat/Chatting/ChatForm.jsx
+++ b/src/components/Chat/Chatting/ChatForm.jsx
@@ -44,20 +44,20 @@ export default function ChatForm({ sendMessage }) {
     >
       <Textarea
         rows={isSmallMobile ? 1 : 3}
-        className="pl-4 pr-12 sm:px-3 min-h-full border-none font-semibold text-white !text-base"
+        className="pl-4 pr-12 sm:px-3 !py-1 sm:py-2.5 min-h-full border-none font-semibold text-white !text-base"
         labelProps={{
           className: "hidden",
         }}
         containerProps={{
           className:
-            "grid min-w-fit h-full bg-gray-900 border border-blue-gray-900 rounded-full sm:rounded-[7px]",
+            "grid min-w-fit h-full bg-gray-900 border border-blue-gray-900 rounded-[7px] overflow-y-auto",
         }}
         {...register("chat")}
       />
       <Button
         type="submit"
         disabled={!isDirty || !isValid}
-        className="absolute sm:relative right-1 top-0 bottom-0 my-auto sm:my-0 p-1 sm:py-3 sm:px-6 bg-transparent sm:bg-brand text-sm shrink-0 transition-none"
+        className="absolute sm:relative right-1 -top-[0.2rem] sm:top-0 bottom-0 flex items-start my-auto sm:my-0 p-1 sm:py-2 sm:px-4 bg-transparent sm:bg-brand text-sm shrink-0 transition-none"
       >
         {isSmallMobile ? (
           <MdSend size={26} className="text-brand -rotate-45 " />

--- a/src/components/Chat/Chatting/ChatRoomMembersModal.jsx
+++ b/src/components/Chat/Chatting/ChatRoomMembersModal.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { v4 as uuidv4 } from "uuid";
+import {
+  Dialog,
+  DialogBody,
+  DialogFooter,
+  List,
+  ListItem,
+  ListItemPrefix,
+  Card,
+  Typography,
+} from "@material-tailwind/react";
+import ProfileImage from "../../Common/Image/ProfileImage";
+import Button from "../../Common/Button";
+
+export default function ChatRoomMembersModal({ isOpen, onClick, members }) {
+  return (
+    <Dialog
+      open={isOpen}
+      handler={onClick}
+      size="xs"
+      className=" max-h-96 overflow-y-auto"
+    >
+      <DialogBody>
+        <Card>
+          <List>
+            {members.map((member) => (
+              <ListItem key={uuidv4()} ripple={false}>
+                <ListItemPrefix>
+                  <ProfileImage imageUrl={member.imageUrl} size="sm" />
+                </ListItemPrefix>
+                <Typography variant="h6" color="blue-gray">
+                  {member.name}
+                </Typography>
+              </ListItem>
+            ))}
+          </List>
+        </Card>
+      </DialogBody>
+      <DialogFooter className="pb-2 pt-0 px-4">
+        <Button onClick={onClick} className="bg-brand text-sm">
+          확인
+        </Button>
+      </DialogFooter>
+    </Dialog>
+  );
+}

--- a/src/components/Chat/Chatting/ChattingColumn.jsx
+++ b/src/components/Chat/Chatting/ChattingColumn.jsx
@@ -15,7 +15,7 @@ export default function ChattingColumn() {
   const memberId = useRecoilValue(memberIdState);
   const {
     error,
-    data: { messages, unreadCount },
+    data: { messages, unreadCount, members },
   } = useQuery({
     queryKey: CHAT_QUERY_KEYS.chatData(chatRoomId),
     queryFn: () => getChattingData({ chatRoomId }),
@@ -51,6 +51,7 @@ export default function ChattingColumn() {
         memberId={memberId}
         chatRoomId={chatRoomId}
         firstChatData={messages}
+        members={members}
         chatList={chatList}
         setChatList={setChatList}
         unreadCount={unreadCount}

--- a/src/components/Chat/Chatting/ChattingColumn.jsx
+++ b/src/components/Chat/Chatting/ChattingColumn.jsx
@@ -19,6 +19,7 @@ export default function ChattingColumn() {
   } = useQuery({
     queryKey: CHAT_QUERY_KEYS.chatData(chatRoomId),
     queryFn: () => getChattingData({ chatRoomId }),
+    refetchOnWindowFocus: false,
   });
 
   const handleChatList = (newChat) => {

--- a/src/components/Chat/Chatting/ChattingColumn.jsx
+++ b/src/components/Chat/Chatting/ChattingColumn.jsx
@@ -1,18 +1,20 @@
 import React, { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
-import { useRecoilValue } from "recoil";
+import { useRecoilValue, useSetRecoilState } from "recoil";
 import { CHAT_QUERY_KEYS } from "../../../constants/queryKeys";
 import useChat from "../../../hooks/useChat";
 import { getChattingData } from "../../../apis/chat";
 import ChatForm from "./ChatForm";
 import { memberIdState } from "../../../recoil/atoms/auth";
 import ChattingList from "./ChattingList";
+import prevChatRoomIdState from "../../../recoil/atoms/chatRoomId";
 
 export default function ChattingColumn() {
   const { chatRoomId } = useParams();
   const [chatList, setChatList] = useState([]);
   const memberId = useRecoilValue(memberIdState);
+  const setPrevChatRoomId = useSetRecoilState(prevChatRoomIdState);
   const {
     error,
     data: { messages, unreadCount, members },
@@ -38,6 +40,7 @@ export default function ChattingColumn() {
 
   useEffect(() => {
     connect();
+    setPrevChatRoomId(chatRoomId);
 
     return () => disconnect();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/Chat/Chatting/ChattingColumn.jsx
+++ b/src/components/Chat/Chatting/ChattingColumn.jsx
@@ -46,7 +46,7 @@ export default function ChattingColumn() {
     return <div>{error.message}</div>;
   }
   return (
-    <article className="flex flex-col gap-1 grow pl-4 md:pl-2 pr-4 py-4 max-h-full">
+    <article className="flex flex-col gap-1 grow pl-4 md:pl-2 pr-4 py-4 max-h-full h-full">
       <ChattingList
         memberId={memberId}
         chatRoomId={chatRoomId}

--- a/src/components/Chat/Chatting/ChattingColumn.jsx
+++ b/src/components/Chat/Chatting/ChattingColumn.jsx
@@ -52,7 +52,7 @@ export default function ChattingColumn() {
   }
   return (
     <article className="flex flex-col gap-1 grow pl-4 md:pl-2 pr-4 py-4 max-h-full h-full w-full md:w-[calc(100vw-42rem)]">
-      <ChattingInfo title={title} members={members} />
+      <ChattingInfo title={title} members={members} chatRoomId={chatRoomId} />
       <ChattingList
         memberId={memberId}
         chatRoomId={chatRoomId}

--- a/src/components/Chat/Chatting/ChattingColumn.jsx
+++ b/src/components/Chat/Chatting/ChattingColumn.jsx
@@ -9,6 +9,7 @@ import ChatForm from "./ChatForm";
 import { memberIdState } from "../../../recoil/atoms/auth";
 import ChattingList from "./ChattingList";
 import prevChatRoomIdState from "../../../recoil/atoms/chatRoomId";
+import ChattingInfo from "./ChattingInfo";
 
 export default function ChattingColumn() {
   const { chatRoomId } = useParams();
@@ -17,7 +18,7 @@ export default function ChattingColumn() {
   const setPrevChatRoomId = useSetRecoilState(prevChatRoomIdState);
   const {
     error,
-    data: { messages, unreadCount, members },
+    data: { title, messages, unreadCount, members },
   } = useQuery({
     queryKey: CHAT_QUERY_KEYS.chatData(chatRoomId),
     queryFn: () => getChattingData({ chatRoomId }),
@@ -50,7 +51,8 @@ export default function ChattingColumn() {
     return <div>{error.message}</div>;
   }
   return (
-    <article className="flex flex-col gap-1 grow pl-4 md:pl-2 pr-4 py-4 max-h-full h-full">
+    <article className="flex flex-col gap-1 grow pl-4 md:pl-2 pr-4 py-4 max-h-full h-full w-full md:w-[calc(100vw-42rem)]">
+      <ChattingInfo title={title} members={members} />
       <ChattingList
         memberId={memberId}
         chatRoomId={chatRoomId}

--- a/src/components/Chat/Chatting/ChattingInfo.jsx
+++ b/src/components/Chat/Chatting/ChattingInfo.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { Typography } from "@material-tailwind/react";
+import { MdPeopleAlt } from "react-icons/md";
+import Button from "../../Common/Button";
+import ChatRoomSettingButton from "../ChatRoomList/ChatRoomSettingButton";
+import useModal from "../../../hooks/useModal";
+import ChatRoomMembersModal from "./ChatRoomMembersModal";
+
+export default function ChattingInfo({ title, members }) {
+  const [isOpen, setIsOpen] = useModal();
+
+  return (
+    <div className="flex items-center justify-between gap-6 px-2 pb-1 border-b border-blue-gray-800">
+      <Typography variant="h5" className="w-full max-w-full truncate">
+        {title}
+      </Typography>
+      <div className="flex gap-2">
+        <Button
+          variant="text"
+          className="p-1 text-white hover:text-brand duration-150"
+          onClick={setIsOpen}
+        >
+          <MdPeopleAlt size={24} />
+        </Button>
+        <ChatRoomMembersModal
+          isOpen={isOpen}
+          onClick={setIsOpen}
+          members={members}
+        />
+        <ChatRoomSettingButton />
+      </div>
+    </div>
+  );
+}

--- a/src/components/Chat/Chatting/ChattingInfo.jsx
+++ b/src/components/Chat/Chatting/ChattingInfo.jsx
@@ -6,7 +6,7 @@ import ChatRoomSettingButton from "../ChatRoomList/ChatRoomSettingButton";
 import useModal from "../../../hooks/useModal";
 import ChatRoomMembersModal from "./ChatRoomMembersModal";
 
-export default function ChattingInfo({ title, members }) {
+export default function ChattingInfo({ title, members, chatRoomId }) {
   const [isOpen, setIsOpen] = useModal();
 
   return (
@@ -27,7 +27,10 @@ export default function ChattingInfo({ title, members }) {
           onClick={setIsOpen}
           members={members}
         />
-        <ChatRoomSettingButton />
+        <ChatRoomSettingButton
+          chatRoomId={chatRoomId}
+          nowChatRoomId={chatRoomId}
+        />
       </div>
     </div>
   );

--- a/src/components/Chat/Chatting/ChattingItem.jsx
+++ b/src/components/Chat/Chatting/ChattingItem.jsx
@@ -1,18 +1,54 @@
 import React from "react";
+import { useRecoilValue } from "recoil";
+import { memberIdState } from "../../../recoil/atoms/auth";
+import { Typography } from "@material-tailwind/react";
+import { getHourAndMinutes } from "../../../utils/date";
+import ProfileImage from "../../Common/Image/ProfileImage";
 
 export default function ChattingItem({
   chatListRef,
   chat: { content, senderId, sendTime },
   index,
+  name,
+  imageUrl,
 }) {
+  const memberId = useRecoilValue(memberIdState);
+  const isMyChat = memberId === senderId;
+
   return (
     <li
+      className={`flex gap-2 ${isMyChat ? "justify-end ml-8" : "mr-8"}`}
       ref={(element) => {
         chatListRef.current[index] = element;
       }}
     >
-      <span>{content}</span>
-      <span className="ml-20">{senderId}</span>
+      {!isMyChat && <ProfileImage imageUrl={imageUrl} size="sm" />}
+      <div>
+        {!isMyChat && (
+          <Typography variant="small" className=" font-normal text-gray-400">
+            {name}
+          </Typography>
+        )}
+        <div className="flex items-end gap-2">
+          <Typography
+            variant="paragraph"
+            className={`px-3 py-[0.125rem] max-w-max bg-white font-normal text-black rounded-md break-all ${
+              isMyChat
+                ? "order-2 bg-yellow-400"
+                : senderId === -1
+                ? "bg-blue-gray-800 text-white"
+                : ""
+            }`}
+          >
+            {content}
+          </Typography>
+          {senderId !== -1 && (
+            <Typography variant="small" className=" font-normal">
+              {getHourAndMinutes(new Date(sendTime))}
+            </Typography>
+          )}
+        </div>
+      </div>
     </li>
   );
 }

--- a/src/components/Chat/Chatting/ChattingList.jsx
+++ b/src/components/Chat/Chatting/ChattingList.jsx
@@ -180,7 +180,7 @@ export default function ChattingList({
       {showButton && (
         <Button
           variant="text"
-          className="sticky bottom-2 left-0 right-0 flex justify-center items-center mx-auto p-1 text-white hover:text-brand bg-blue-gray-600 rounded-full duration-150 z-30"
+          className="sticky bottom-2 left-0 right-0 flex justify-center items-center mx-auto p-1 text-white hover:text-brand bg-blue-gray-600 rounded-full duration-150 z-30 opacity-70"
           onClick={handleScrollClick}
         >
           <MdOutlineArrowCircleDown size={32} />

--- a/src/components/Chat/Chatting/ChattingList.jsx
+++ b/src/components/Chat/Chatting/ChattingList.jsx
@@ -34,11 +34,14 @@ export default function ChattingList({
         lastPage.messages.length > 0 ? lastPage.messages[0].sendTime : null,
     });
   const [observe, unobserve] = useIntersectionObserver(() => {
+    if (isFetchingNextPage) return;
+
     fetchNextPage();
     const scrollHeight = chatListContainerRef.current?.scrollHeight;
     setPrevScrollHeight(scrollHeight);
   });
 
+  // 채팅 추가될 때 스크롤
   useLayoutEffect(() => {
     if (
       chatList.length === 0 ||
@@ -60,17 +63,6 @@ export default function ChattingList({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chatList, firstChatData, memberId]);
 
-  // 추가 데이터가 가져올 때 스크롤 위치 고정
-  useLayoutEffect(() => {
-    if (!prevScrollHeight) return;
-
-    const scrollHeight = chatListContainerRef.current.scrollHeight;
-    chatListContainerRef.current.scrollTo({
-      top: scrollHeight - prevScrollHeight,
-    });
-    return () => setPrevScrollHeight(0);
-  }, [chatList, prevScrollHeight]);
-
   // 첫 렌더링 시 읽지 않은 채팅이 가운데 보이게 스크롤
   // 읽지 않은 채팅이 없으면 가장 아래로 스크롤
   useLayoutEffect(() => {
@@ -85,6 +77,21 @@ export default function ChattingList({
       block: "center",
     });
   }, [chatList, unreadCount, firstChatData, hasNextPage]);
+
+  // 추가 데이터가 가져올 때 스크롤 위치 고정
+  useLayoutEffect(() => {
+    if (!prevScrollHeight) return;
+
+    const scrollHeight = chatListContainerRef.current.scrollHeight;
+    if (scrollHeight - prevScrollHeight === 32) {
+      return () => setPrevScrollHeight(0);
+    }
+
+    chatListContainerRef.current.scrollTo({
+      top: scrollHeight - prevScrollHeight,
+    });
+    return () => setPrevScrollHeight(0);
+  }, [chatList, prevScrollHeight]);
 
   useEffect(() => {
     const dataLength = data.pages.length;
@@ -143,3 +150,7 @@ function findMember(members, senderId) {
     name: members[memberIndex]?.name || "",
   };
 }
+
+// function getChatData(data) {
+//   return data.pages?.reduce((prev, cur) => [...cur.messages, ...prev], []);
+// }

--- a/src/components/Chat/Chatting/ChattingList.jsx
+++ b/src/components/Chat/Chatting/ChattingList.jsx
@@ -29,9 +29,19 @@ export default function ChattingList({
           chatRoomId,
           cursor: pageParam,
         }),
-      initialPageParam: new Date().toISOString(),
-      getNextPageParam: (lastPage) =>
-        lastPage.messages.length > 0 ? lastPage.messages[0].sendTime : null,
+      initialPageParam: new Date(0).toISOString(),
+      getNextPageParam: (lastPage, allPages) => {
+        if (allPages.length === 1) {
+          if (firstChatData[0].senderId === -1) {
+            return firstChatData[1]?.sendTime;
+          }
+          return firstChatData[0].sendTime;
+        }
+
+        return lastPage.messages.length > 0
+          ? lastPage.messages[0].sendTime
+          : null;
+      },
     });
   const [observe, unobserve] = useIntersectionObserver(() => {
     if (isFetchingNextPage) return;

--- a/src/components/Chat/Chatting/ChattingList.jsx
+++ b/src/components/Chat/Chatting/ChattingList.jsx
@@ -12,6 +12,7 @@ export default function ChattingList({
   memberId,
   chatRoomId,
   firstChatData,
+  members,
   chatList,
   setChatList,
   unreadCount,
@@ -108,18 +109,37 @@ export default function ChattingList({
     return <div>{error.message}</div>;
   }
   return (
-    <ul ref={chatListContainerRef} className="grow overflow-y-auto">
+    <ul
+      ref={chatListContainerRef}
+      className="flex flex-col gap-2 grow overflow-y-auto"
+    >
       <div ref={observerRef} className="flex justify-center items-center">
         {isFetchingNextPage && <Spinner className="h-8 w-8 text-brand" />}
       </div>
-      {chatList.map((chat, index) => (
-        <ChattingItem
-          key={uuidv4()}
-          chatListRef={chatListRef}
-          chat={chat}
-          index={index}
-        />
-      ))}
+      {chatList.map((chat, index) => {
+        const { name, imageUrl } = findMember(members, chat.senderId);
+        return (
+          <ChattingItem
+            key={uuidv4()}
+            chatListRef={chatListRef}
+            chat={chat}
+            index={index}
+            name={name}
+            imageUrl={imageUrl}
+          />
+        );
+      })}
     </ul>
   );
+}
+
+function findMember(members, senderId) {
+  const memberIndex = members.findIndex(
+    (member) => member.memberId === senderId
+  );
+
+  return {
+    imageUrl: members[memberIndex]?.imageUrl || "",
+    name: members[memberIndex]?.name || "",
+  };
 }

--- a/src/components/Common/Image/ProfileImage.jsx
+++ b/src/components/Common/Image/ProfileImage.jsx
@@ -8,18 +8,16 @@ const SIZE = {
 };
 
 export default function ProfileImage({ imageUrl, size }) {
+  const onErrorImg = (e) => {
+    e.target.src = defaultProfile;
+  };
+
   return (
-    <picture
-      className={`relative ${SIZE[size]} rounded-full bg-dark_gray overflow-hidden`}
-    >
-      <source srcSet={imageUrl} />
-      <img
-        src={defaultProfile}
-        alt={`${imageUrl ? "" : "기본 "}프로필 이미지`}
-        className={`absolute inset-0 m-auto ${
-          imageUrl ? "w-full h-full object-cover" : "w-3/5 h-3/5 object-contain"
-        }`}
-      />
-    </picture>
+    <img
+      src={imageUrl}
+      alt={`${imageUrl ? "" : "기본 "}프로필 이미지`}
+      className={`rounded-full ${SIZE[size]}`}
+      onError={onErrorImg}
+    />
   );
 }

--- a/src/constants/recoilKeys.js
+++ b/src/constants/recoilKeys.js
@@ -11,3 +11,7 @@ export const NEW_CHAT_KEYS = {
   newChatMembers: "newChatMembers",
   createNewChat: "createNewChat",
 };
+
+export const PREV_CHATROOMID_RECOIL_KEYS = {
+  prevChatRoomId: "chatRoomId",
+};

--- a/src/recoil/atoms/chatRoomId.js
+++ b/src/recoil/atoms/chatRoomId.js
@@ -1,0 +1,9 @@
+import { atom } from "recoil";
+import { PREV_CHATROOMID_RECOIL_KEYS } from "../../constants/recoilKeys";
+
+const prevChatRoomIdState = atom({
+  key: PREV_CHATROOMID_RECOIL_KEYS.prevChatRoomId,
+  default: null,
+});
+
+export default prevChatRoomIdState;


### PR DESCRIPTION
## ⭐Key Changes
1. 채팅방 디자인 적용(이미지, 이름, 시간 추가)
2. 읽지 않은 채팅 개수 100개 이상 넘어가면 "100+"로 표기
> 채팅 상세 페이지 첫 렌더링 시 읽지 않은 메세지 중 첫 번째 채팅이 화면 가운데로 오게 스크롤
> 기존: 첫 렌더링 시 최근 100개의 채팅 가져오기
> 수정: 읽지 않은 채팅 개수가 100개 이상인 경우 읽지 않은 채팅 모두를 첫 렌더링에 받아오고, 100개 미만인 경우 가장 최근 채팅 100개를 받아온다.

3. 채팅 상세 페이지에서 상단으로 일정 구간 이상 스크롤 시 하단 스크롤 버튼 생성
4. 채팅 상세 페이지에서 채팅 리스트 페이지로 이동 시 읽지 않은 채팅이 업데이트 되지 않는 현상 해결
5. 채팅방 멤버 확인 모달 구현
6. 채팅방 나가기 기능 구현

