### PR TITLE
팔로우 목록 페이지네이션

### DIFF
--- a/src/apis/user.js
+++ b/src/apis/user.js
@@ -37,10 +37,10 @@ export const getUserDataWithLogin = ({ selectedMemberId }) =>
     })
     .then((response) => response.data);
 
-export const getFollowingUsersData = ({ cursor }) =>
+export const getFollowingUsersData = ({ pageNumber, pageSize = 30 }) =>
   instance
     .get(`${ENDPOINT}/follow/followings`, {
-      params: { cursor },
+      params: { pageNumber, pageSize },
     })
     .then((response) => response.data);
 

--- a/src/components/Main/Common/Pagination.jsx
+++ b/src/components/Main/Common/Pagination.jsx
@@ -1,0 +1,70 @@
+import React from "react";
+import {
+  MdOutlineKeyboardArrowLeft,
+  MdOutlineKeyboardArrowRight,
+  MdOutlineKeyboardDoubleArrowRight,
+  MdOutlineKeyboardDoubleArrowLeft,
+} from "react-icons/md";
+import { v4 as uuidv4 } from "uuid";
+import { IconButton } from "@material-tailwind/react";
+import Button from "../../Common/Button";
+
+export default function Pagination({
+  pageStart,
+  page,
+  totalPage,
+  onNextClick,
+  onLastPageClick,
+  onPrevClick,
+  onFirstPageClick,
+  getItemProps,
+}) {
+  return (
+    <div className="flex justify-center items-center gap-4 py-4">
+      <Button
+        variant="text"
+        className="flex items-center gap-2 p-1 text-white hover:text-brand"
+        onClick={onFirstPageClick}
+        disabled={page === 1}
+      >
+        <MdOutlineKeyboardDoubleArrowLeft size={24} />
+      </Button>
+      <Button
+        variant="text"
+        className="flex items-center gap-2 p-1 text-white hover:text-brand"
+        onClick={onPrevClick}
+        disabled={page === 1}
+      >
+        <MdOutlineKeyboardArrowLeft size={24} />
+      </Button>
+      <div className="flex items-center gap-2">
+        {Array.from(
+          {
+            length: totalPage - pageStart >= 5 ? 5 : totalPage - pageStart + 1,
+          },
+          (_, index) => pageStart + index
+        ).map((value) => (
+          <IconButton key={uuidv4()} {...getItemProps(value)}>
+            {value}
+          </IconButton>
+        ))}
+      </div>
+      <Button
+        variant="text"
+        className="flex items-center gap-2 p-1 text-white hover:text-brand"
+        onClick={onNextClick}
+        disabled={page === totalPage}
+      >
+        <MdOutlineKeyboardArrowRight size={24} />
+      </Button>
+      <Button
+        variant="text"
+        className="flex items-center gap-2 p-1 text-white hover:text-brand"
+        onClick={onLastPageClick}
+        disabled={page === totalPage}
+      >
+        <MdOutlineKeyboardDoubleArrowRight size={24} />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/Main/FollowingPage.jsx
+++ b/src/components/Main/FollowingPage.jsx
@@ -1,0 +1,113 @@
+import React, { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  MdOutlineKeyboardArrowLeft,
+  MdOutlineKeyboardArrowRight,
+  MdOutlineKeyboardDoubleArrowRight,
+  MdOutlineKeyboardDoubleArrowLeft,
+} from "react-icons/md";
+import { v4 as uuidv4 } from "uuid";
+import { USERS_QUERY_KEYS } from "../../constants/queryKeys";
+import { getFollowingUsersData } from "../../apis/user";
+import UsersGrid from "./User/UsersGrid";
+import Button from "../Common/Button";
+import { IconButton } from "@material-tailwind/react";
+
+export default function FollowingPage() {
+  const [page, setPage] = useState(1);
+  const [pageStart, setPageStart] = useState(1);
+  const {
+    data: { data: userData, totalPage },
+  } = useQuery({
+    queryKey: USERS_QUERY_KEYS.followingUsers(page),
+    queryFn: () => getFollowingUsersData({ pageNumber: page }),
+    keepPreviousData: true,
+  });
+
+  const getItemProps = (value) => ({
+    variant: page === value ? "filled" : "text",
+    color: "white",
+    className: `${page === value ? "bg-brand text-white" : ""}`,
+    ripple: false,
+    onClick: () => {
+      setPage(value);
+      if (value < page) {
+        if (page % 5 === 1) setPageStart(page - 5);
+      } else {
+        if (page % 5 === 0) setPageStart(page + 1);
+      }
+    },
+  });
+  const handleNextClick = () => {
+    if (page === totalPage) return;
+
+    if (page % 5 === 0) setPageStart(page + 1);
+    setPage((prev) => prev + 1);
+  };
+  const handleLastPageClick = () => {
+    setPage(totalPage);
+    setPageStart(totalPage - ((totalPage % 5) - 1));
+  };
+  const handlePrevClick = () => {
+    if (page === 1) return;
+
+    if (page % 5 === 1) setPageStart(page - 5);
+    setPage((prev) => prev - 1);
+  };
+  const handleFirstPageClick = () => {
+    setPage(1);
+    setPageStart(1);
+  };
+  return (
+    <section className="flex flex-col justify-between gap-4 h-full">
+      <UsersGrid users={userData} isFollowing={true} />
+      <div className="flex justify-center items-center gap-4 py-4">
+        <Button
+          variant="text"
+          className="flex items-center gap-2 p-1 text-white hover:text-brand"
+          onClick={handleFirstPageClick}
+          disabled={page === 1}
+        >
+          <MdOutlineKeyboardDoubleArrowLeft size={24} />
+        </Button>
+        <Button
+          variant="text"
+          className="flex items-center gap-2 p-1 text-white hover:text-brand"
+          onClick={handlePrevClick}
+          disabled={page === 1}
+        >
+          <MdOutlineKeyboardArrowLeft size={24} />
+        </Button>
+        <div className="flex items-center gap-2">
+          {Array.from(
+            {
+              length:
+                totalPage - pageStart >= 5 ? 5 : totalPage - pageStart + 1,
+            },
+            (_, index) => pageStart + index
+          ).map((value) => (
+            <IconButton key={uuidv4()} {...getItemProps(value)}>
+              {value}
+            </IconButton>
+          ))}
+        </div>
+        <Button
+          variant="text"
+          className="flex items-center gap-2 p-1 text-white hover:text-brand"
+          onClick={handleNextClick}
+          disabled={page === totalPage}
+        >
+          <MdOutlineKeyboardArrowRight size={24} />
+        </Button>
+        <Button
+          variant="text"
+          className="flex items-center gap-2 p-1 text-white hover:text-brand"
+          onClick={handleLastPageClick}
+          disabled={page === totalPage}
+        >
+          <MdOutlineKeyboardDoubleArrowRight size={24} />
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Main/FollowingPage.jsx
+++ b/src/components/Main/FollowingPage.jsx
@@ -1,17 +1,9 @@
 import React, { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import {
-  MdOutlineKeyboardArrowLeft,
-  MdOutlineKeyboardArrowRight,
-  MdOutlineKeyboardDoubleArrowRight,
-  MdOutlineKeyboardDoubleArrowLeft,
-} from "react-icons/md";
-import { v4 as uuidv4 } from "uuid";
 import { USERS_QUERY_KEYS } from "../../constants/queryKeys";
 import { getFollowingUsersData } from "../../apis/user";
 import UsersGrid from "./User/UsersGrid";
-import Button from "../Common/Button";
-import { IconButton } from "@material-tailwind/react";
+import Pagination from "./Common/Pagination";
 
 export default function FollowingPage() {
   const [page, setPage] = useState(1);
@@ -61,53 +53,16 @@ export default function FollowingPage() {
   return (
     <section className="flex flex-col justify-between gap-4 h-full">
       <UsersGrid users={userData} isFollowing={true} />
-      <div className="flex justify-center items-center gap-4 py-4">
-        <Button
-          variant="text"
-          className="flex items-center gap-2 p-1 text-white hover:text-brand"
-          onClick={handleFirstPageClick}
-          disabled={page === 1}
-        >
-          <MdOutlineKeyboardDoubleArrowLeft size={24} />
-        </Button>
-        <Button
-          variant="text"
-          className="flex items-center gap-2 p-1 text-white hover:text-brand"
-          onClick={handlePrevClick}
-          disabled={page === 1}
-        >
-          <MdOutlineKeyboardArrowLeft size={24} />
-        </Button>
-        <div className="flex items-center gap-2">
-          {Array.from(
-            {
-              length:
-                totalPage - pageStart >= 5 ? 5 : totalPage - pageStart + 1,
-            },
-            (_, index) => pageStart + index
-          ).map((value) => (
-            <IconButton key={uuidv4()} {...getItemProps(value)}>
-              {value}
-            </IconButton>
-          ))}
-        </div>
-        <Button
-          variant="text"
-          className="flex items-center gap-2 p-1 text-white hover:text-brand"
-          onClick={handleNextClick}
-          disabled={page === totalPage}
-        >
-          <MdOutlineKeyboardArrowRight size={24} />
-        </Button>
-        <Button
-          variant="text"
-          className="flex items-center gap-2 p-1 text-white hover:text-brand"
-          onClick={handleLastPageClick}
-          disabled={page === totalPage}
-        >
-          <MdOutlineKeyboardDoubleArrowRight size={24} />
-        </Button>
-      </div>
+      <Pagination
+        pageStart={pageStart}
+        page={page}
+        totalPage={totalPage}
+        onFirstPageClick={handleFirstPageClick}
+        onLastPageClick={handleLastPageClick}
+        onPrevClick={handlePrevClick}
+        onNextClick={handleNextClick}
+        getItemProps={getItemProps}
+      />
     </section>
   );
 }

--- a/src/components/Main/MainPageMain.jsx
+++ b/src/components/Main/MainPageMain.jsx
@@ -3,31 +3,20 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { Spinner } from "@material-tailwind/react";
 import UsersGrid from "./User/UsersGrid";
 import useIntersectionObserver from "../../hooks/useIntersectionObserver";
-import {
-  getUsersDataWithLogin,
-  getFollowingUsersData,
-  getUsersData,
-} from "../../apis/user";
+import { getUsersDataWithLogin, getUsersData } from "../../apis/user";
 import { USERS_QUERY_KEYS } from "../../constants/queryKeys";
 import { useRecoilValue } from "recoil";
 import { isLoggedInState } from "../../recoil/atoms/auth";
 
 const USERS_COUNT = 15;
 
-export default function MainPageMain({ filter, filters }) {
+export default function MainPageMain({ filters }) {
   const observerRef = useRef(null);
   const isLoggedIn = useRecoilValue(isLoggedInState);
   const { fetchNextPage, hasNextPage, isFetchingNextPage, data, error } =
     useInfiniteQuery({
-      queryKey:
-        filter === ""
-          ? USERS_QUERY_KEYS.followingUsers
-          : USERS_QUERY_KEYS.usersData(filters),
+      queryKey: USERS_QUERY_KEYS.usersData(filters),
       queryFn: ({ pageParam = null }) => {
-        if (filter === "")
-          return getFollowingUsersData({
-            cursor: pageParam,
-          });
         if (isLoggedIn)
           return getUsersDataWithLogin({
             cursor: pageParam,

--- a/src/components/Main/SideBar/SideBarCategoryList.jsx
+++ b/src/components/Main/SideBar/SideBarCategoryList.jsx
@@ -3,13 +3,13 @@ import { Card, List, ListItem } from "@material-tailwind/react";
 import { v4 as uuidv4 } from "uuid";
 import SideBarCategoryItem from "./SideBarCategoryItem";
 import { CATEGORIES } from "../../../constants/category";
-import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import filterState from "../../../recoil/atoms/filter";
 import { isLoggedInState } from "../../../recoil/atoms/auth";
 
 export default function SideBarCategoryList({ createNewChat }) {
   const isLoggedIn = useRecoilValue(isLoggedInState);
-  const setFilter = useSetRecoilState(filterState);
+  const [filter, setFilter] = useRecoilState(filterState);
 
   const handleFollowClick = () => {
     setFilter("");
@@ -28,7 +28,9 @@ export default function SideBarCategoryList({ createNewChat }) {
           <div className="pt-2 border-t border-blue-gray-100">
             <ListItem
               ripple={false}
-              className="text-white"
+              className={`text-white ${
+                filter.length === 0 ? "bg-blue-gray-50 bg-opacity-80" : ""
+              }`}
               onClick={handleFollowClick}
             >
               FOLLOWING

--- a/src/components/Main/User/UsersGrid.jsx
+++ b/src/components/Main/User/UsersGrid.jsx
@@ -2,12 +2,14 @@ import React from "react";
 import { v4 as uuidv4 } from "uuid";
 import UserCard from "./UserCard";
 
-export default function UsersGrid({ users }) {
+export default function UsersGrid({ users, isFollowing }) {
   return (
     <ul className="grid sm:grid-cols-2 lg:grid-cols-3 grid-cols-1 gap-4">
-      {users.map((page) =>
-        page.data.map((user) => <UserCard key={uuidv4()} user={user} />)
-      )}
+      {isFollowing
+        ? users.map((user) => <UserCard key={uuidv4()} user={user} />)
+        : users.map((page) =>
+            page.data.map((user) => <UserCard key={uuidv4()} user={user} />)
+          )}
     </ul>
   );
 }

--- a/src/constants/queryKeys.js
+++ b/src/constants/queryKeys.js
@@ -6,7 +6,7 @@ export const USERS_QUERY_KEYS = {
   usersData: (categories) => ["usersData", categories],
   userData: (memberId) => ["userData", memberId],
   userDataWithFollowData: (memberId) => ["userDataWithFollowData", memberId],
-  followingUsers: ["followingUsers"],
+  followingUsers: (page) => ["followingUsers", page],
   searchWithEmail: (query) => ["searchWithEmail", query],
 };
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -11,6 +11,7 @@ import CreateChatButtonGroup from "../components/Main/Common/CreateChatButtonGro
 import UserGridSkeleton from "../components/Main/User/Skeleton/UserGridSkeleton";
 import { isLoggedInState } from "../recoil/atoms/auth";
 import MainPageMain from "../components/Main/MainPageMain";
+import FollowingPage from "../components/Main/FollowingPage";
 
 export default function HomePage() {
   const [isOpen, handleModalClick] = useModal();
@@ -35,16 +36,20 @@ export default function HomePage() {
     setFilters([]);
   }, [filter]);
   return (
-    <main className="relative flex w-full h-full">
+    <main className="relative flex w-full h-[calc(100vh-3.5rem)] sm:h-[calc(100vh-5rem)]">
       <SideBar isModalOpen={isOpen} onModalClick={handleModalClick} />
-      <div className="relative flex flex-col mb-12 p-4 md:ml-64 w-full">
+      <div className="relative flex flex-col p-4 md:ml-64 w-full">
         <Categories
           filter={filter}
           filters={filters}
           onFilterClick={handleFilterClick}
         />
         <Suspense fallback={<UserGridSkeleton />}>
-          <MainPageMain filter={filter} filters={filters} />
+          {filter.length === 0 ? (
+            <FollowingPage />
+          ) : (
+            <MainPageMain filters={filters} />
+          )}
         </Suspense>
         {createNewChat && (
           <CreateChatButtonGroup


### PR DESCRIPTION
## ⭐Key Changes
1. 팔로우 목록 페이지네이션
> 페이지 목록은 최대 5개까지 보이고, 다음(이전), 마지막(처음) 페이지로 이동가능한 버튼 구현
만약 8페이지까지 존재하는 경우 5페이지에서 6페이지로 넘어갈 때 6 ~ 8 페이지 이동 버튼이 보이게 구현

