### PR TITLE
채팅방 나가기 및 데이터 중복 요청 처리

### DIFF
--- a/src/apis/chat.js
+++ b/src/apis/chat.js
@@ -12,27 +12,26 @@ export const createChatRoom = ({ title, memberIds }) =>
 
 export const getChattingData = ({ chatRoomId }) =>
   instance
-    .post(`${ENDPOINT}/room`, {
-      chatRoomId,
+    .get(`${ENDPOINT}/room`, {
+      params: { chatRoomId },
     })
     .then((response) => response.data);
 
 export const getChattingWithCursor = ({ chatRoomId, cursor }) =>
   instance
-    .post(`${ENDPOINT}/message/cursor`, {
-      chatRoomId,
-      cursor,
+    .get(`${ENDPOINT}/message/cursor`, {
+      params: { chatRoomId, cursor },
     })
     .then((response) => response.data);
 
 export const disconnectChatRoom = ({ chatRoomId }) =>
   instance
-    .get(`${ENDPOINT}/leave`, { params: { chatRoomId } })
+    .get(`${ENDPOINT}/out`, { params: { chatRoomId } })
     .then((response) => response.data);
 
 export const exitChatRoom = ({ chatRoomId }) =>
   instance
-    .get(`${ENDPOINT}/exit`, { params: { chatRoomId } })
+    .post(`${ENDPOINT}/leave`, { chatRoomId })
     .then((response) => response.data);
 
 export const changeRoomTitle = ({ chatRoomId, newTitle }) =>

--- a/src/apis/chat.js
+++ b/src/apis/chat.js
@@ -41,3 +41,11 @@ export const changeRoomTitle = ({ chatRoomId, newTitle }) =>
       newTitle,
     })
     .then((response) => response.data);
+
+export const inviteUserWithEmail = ({ chatRoomId, memberId }) =>
+  instance
+    .post(`${ENDPOINT}/invite`, {
+      chatRoomId,
+      invitedMemberId: memberId,
+    })
+    .then((response) => response.data);

--- a/src/apis/user.js
+++ b/src/apis/user.js
@@ -64,11 +64,3 @@ export const searchWithEmail = ({ email, limit = 10 }) =>
       params: { email, limit },
     })
     .then((response) => response.data);
-
-export const inviteUserWithEmail = ({ chatRoomId, memberId }) =>
-  instance
-    .post(`${ENDPOINT}/chat/invite`, {
-      chatRoomId,
-      invitedMemberId: memberId,
-    })
-    .then((response) => response.data);

--- a/src/components/Chat/ChatRoomList/ChatRoom.jsx
+++ b/src/components/Chat/ChatRoomList/ChatRoom.jsx
@@ -30,34 +30,32 @@ export default function ChatRoom({
     memberId,
     (newChat) => {
       const { senderId, sendTime, content } = JSON.parse(newChat);
-      if (senderId < -1)
-        setChatRooms((prevChatRooms) => {
-          const index = prevChatRooms.findIndex(
-            (room) => room.chatRoomId === chatRoomId
-          );
-          if (index === -1) return prevChatRooms;
-          const { memberCount, unreadCount, lastMessage } =
-            prevChatRooms[index];
-          return [
-            {
-              ...prevChatRooms[index],
-              memberCount:
-                senderId === -2
-                  ? memberCount - 1
-                  : senderId === -3
-                  ? memberCount + 1
-                  : memberCount,
-              unreadCount:
-                nowChatRoomId === chatRoomId ? unreadCount : unreadCount + 1,
-              lastMessage: {
-                ...lastMessage,
-                sendTime,
-                content,
-              },
+      setChatRooms((prevChatRooms) => {
+        const index = prevChatRooms.findIndex(
+          (room) => room.chatRoomId === chatRoomId
+        );
+        if (index === -1) return prevChatRooms;
+        const { memberCount, unreadCount, lastMessage } = prevChatRooms[index];
+        return [
+          {
+            ...prevChatRooms[index],
+            memberCount:
+              senderId === -2
+                ? memberCount - 1
+                : senderId === -3
+                ? memberCount + 1
+                : memberCount,
+            unreadCount:
+              nowChatRoomId === chatRoomId ? unreadCount : unreadCount + 1,
+            lastMessage: {
+              ...lastMessage,
+              sendTime,
+              content,
             },
-            ...prevChatRooms.filter((room) => room.chatRoomId !== chatRoomId),
-          ];
-        });
+          },
+          ...prevChatRooms.filter((room) => room.chatRoomId !== chatRoomId),
+        ];
+      });
     }
   );
 

--- a/src/components/Chat/ChatRoomList/ChatRoom.jsx
+++ b/src/components/Chat/ChatRoomList/ChatRoom.jsx
@@ -31,33 +31,33 @@ export default function ChatRoom({
     (newChat) => {
       const { senderId, sendTime, content } = JSON.parse(newChat);
       if (senderId < -1)
-        queryClient.invalidateQueries(CHAT_QUERY_KEYS.chatData(chatRoomId));
-      setChatRooms((prevChatRooms) => {
-        const index = prevChatRooms.findIndex(
-          (room) => room.chatRoomId === chatRoomId
-        );
-        if (index === -1) return prevChatRooms;
-        const { memberCount, unreadCount, lastMessage } = prevChatRooms[index];
-        return [
-          {
-            ...prevChatRooms[index],
-            memberCount:
-              senderId === -2
-                ? memberCount - 1
-                : senderId === -3
-                ? memberCount + 1
-                : memberCount,
-            unreadCount:
-              nowChatRoomId === chatRoomId ? unreadCount : unreadCount + 1,
-            lastMessage: {
-              ...lastMessage,
-              sendTime,
-              content,
+        setChatRooms((prevChatRooms) => {
+          const index = prevChatRooms.findIndex(
+            (room) => room.chatRoomId === chatRoomId
+          );
+          if (index === -1) return prevChatRooms;
+          const { memberCount, unreadCount, lastMessage } =
+            prevChatRooms[index];
+          return [
+            {
+              ...prevChatRooms[index],
+              memberCount:
+                senderId === -2
+                  ? memberCount - 1
+                  : senderId === -3
+                  ? memberCount + 1
+                  : memberCount,
+              unreadCount:
+                nowChatRoomId === chatRoomId ? unreadCount : unreadCount + 1,
+              lastMessage: {
+                ...lastMessage,
+                sendTime,
+                content,
+              },
             },
-          },
-          ...prevChatRooms.filter((room) => room.chatRoomId !== chatRoomId),
-        ];
-      });
+            ...prevChatRooms.filter((room) => room.chatRoomId !== chatRoomId),
+          ];
+        });
     }
   );
 
@@ -65,6 +65,7 @@ export default function ChatRoom({
     if (nowChatRoomId) {
       await disconnectChatRoom({ chatRoomId: nowChatRoomId });
     }
+    queryClient.removeQueries(CHAT_QUERY_KEYS.chatDataWithCursor(chatRoomId));
     navigate(`/chatting/${chatRoomId}`);
   };
 

--- a/src/components/Chat/Chatting/ChattingList.jsx
+++ b/src/components/Chat/Chatting/ChattingList.jsx
@@ -32,7 +32,7 @@ export default function ChattingList({
           chatRoomId,
           cursor: pageParam,
         }),
-      initialPageParam: new Date(0).toISOString(),
+      initialPageParam: null,
       getNextPageParam: (lastPage, allPages) => {
         const length = firstChatData.length;
         if (length < 100) return null;

--- a/src/components/Chat/Chatting/ChattingList.jsx
+++ b/src/components/Chat/Chatting/ChattingList.jsx
@@ -7,7 +7,6 @@ import { CHAT_QUERY_KEYS } from "../../../constants/queryKeys";
 import useIntersectionObserver from "../../../hooks/useIntersectionObserver";
 import { getChattingWithCursor } from "../../../apis/chat";
 import ChattingItem from "./ChattingItem";
-import { queryClient } from "../../../apis/queryClient";
 import Button from "../../Common/Button";
 
 export default function ChattingList({
@@ -148,10 +147,6 @@ export default function ChattingList({
 
     return () => unobserve(observer);
   }, [observerRef, hasNextPage, observe, unobserve]);
-
-  useEffect(() => {
-    queryClient.removeQueries(CHAT_QUERY_KEYS.chatDataWithCursor(chatRoomId));
-  }, [chatRoomId]);
 
   if (error) {
     return <div>{error.message}</div>;

--- a/src/components/Chat/Chatting/ChattingList.jsx
+++ b/src/components/Chat/Chatting/ChattingList.jsx
@@ -33,16 +33,12 @@ export default function ChattingList({
         }),
       initialPageParam: null,
       getNextPageParam: (lastPage, allPages) => {
-        const length = firstChatData.length;
-        if (length < 100) return null;
-        if (allPages.length === 1) {
-          if (length === 100) return firstChatData[0]?.sendTime;
-          return firstChatData[1]?.sendTime;
-        }
+        const lastSendTime = new Date(firstChatData[0].sendTime);
+        const nextCursor = new Date(lastPage.nextCursor);
 
-        return lastPage.messages.length > 0
-          ? lastPage.messages[0].sendTime
-          : null;
+        return lastSendTime > nextCursor
+          ? lastPage.nextCursor
+          : firstChatData[0].sendTime;
       },
     });
   const [observe, unobserve] = useIntersectionObserver(() => {

--- a/src/components/Chat/Modal/InviteModal/SearchResultItem.jsx
+++ b/src/components/Chat/Modal/InviteModal/SearchResultItem.jsx
@@ -4,7 +4,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
 import { useSetRecoilState } from "recoil";
 import ProfileImage from "../../../Common/Image/ProfileImage";
-import { inviteUserWithEmail } from "../../../../apis/user";
+import { inviteUserWithEmail } from "../../../../apis/chat";
 import { toastState } from "../../../../recoil/atoms/toast";
 
 export default function SearchResultItem({


### PR DESCRIPTION
## ⭐Key Changes
1. 채팅방 나가기 및 데이터 중복 요청 해결
> `removeQueries` 를 ChattingList 컴포넌트 내부에서 실행해서 데이터 중복 요청이 발생 => 코드를 ChatRoom 컴포넌트로 이동하여 중복 요청을 해결

2. 백엔드 리팩토링으로 채팅관련 API 주소 및 요청방식 수정
3. Cursor 기반 채팅 데이터 `getNextPageParam` 함수 변경

## 📌 issue
close #이슈번호

